### PR TITLE
Implement `eth_getFilterChanges` for filter API v2

### DIFF
--- a/rpc/eth_pubsub.go
+++ b/rpc/eth_pubsub.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Conflux-Chain/confura/node"
 	"github.com/Conflux-Chain/confura/util"
 	rpcutil "github.com/Conflux-Chain/confura/util/rpc"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/openweb3/go-rpc-provider"
 	"github.com/openweb3/web3go/types"
 	"github.com/sirupsen/logrus"
@@ -146,40 +145,7 @@ func matchEthPubSubLogFilter(log *types.Log, filter *types.FilterQuery) bool {
 		return true
 	}
 
-	return matchEthLogFilterAddr(log, filter) && matchEthLogFilterTopic(log, filter)
-}
-
-func matchEthLogFilterTopic(log *types.Log, filter *types.FilterQuery) bool {
-	find := func(t common.Hash, topics []common.Hash) bool {
-		for _, topic := range topics {
-			if t == topic {
-				return true
-			}
-		}
-		return false
-	}
-
-	for i, topics := range filter.Topics {
-		if len(topics) == 0 {
-			continue
-		}
-
-		if len(log.Topics) <= i || !find(log.Topics[i], topics) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func matchEthLogFilterAddr(log *types.Log, filter *types.FilterQuery) bool {
-	for _, addr := range filter.Addresses {
-		if log.Address == addr {
-			return true
-		}
-	}
-
-	return len(filter.Addresses) == 0
+	return util.IncludeEthLogAddrs(log, filter.Addresses) && util.MatchEthLogTopics(log, filter.Topics)
 }
 
 func isEmptyEthLogFilter(filter types.FilterQuery) bool {

--- a/util/blockchain.go
+++ b/util/blockchain.go
@@ -190,3 +190,38 @@ func GetEthHardforkBlockNumber(chainId uint64) web3goTypes.BlockNumber {
 
 	return ethHardforkBlockNumberDevnet
 }
+
+// MatchEthLogTopics checks if the eSpace event log matches with the given topics condition
+func MatchEthLogTopics(log *web3goTypes.Log, topics [][]common.Hash) bool {
+	find := func(t common.Hash, topics []common.Hash) bool {
+		for _, topic := range topics {
+			if t == topic {
+				return true
+			}
+		}
+		return false
+	}
+
+	for i, topics := range topics {
+		if len(topics) == 0 {
+			continue
+		}
+
+		if len(log.Topics) <= i || !find(log.Topics[i], topics) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IncludeEthLogAddrs checks if the eSpace event logs include any of the given addresses
+func IncludeEthLogAddrs(log *web3goTypes.Log, addresses []common.Address) bool {
+	for _, addr := range addresses {
+		if log.Address == addr {
+			return true
+		}
+	}
+
+	return len(addresses) == 0
+}

--- a/virtualfilter/api.go
+++ b/virtualfilter/api.go
@@ -197,7 +197,7 @@ func (api *FilterApi) GetFilterLogs(nodeUrl string, id rpc.ID) (logs []types.Log
 
 // GetFilterChanges returns the data for the proxy filter with the given id since
 // last time it was called. This can be used for polling.
-func (api *FilterApi) GetFilterChanges(nodeUrl string, id rpc.ID) (res interface{}, err error) {
+func (api *FilterApi) GetFilterChanges(nodeUrl string, id rpc.ID) (res *types.FilterChanges, err error) {
 	f, found := api.getFilter(id)
 	if !found {
 		return nil, errFilterNotFound

--- a/virtualfilter/chain.go
+++ b/virtualfilter/chain.go
@@ -123,8 +123,8 @@ type FilterChain struct {
 	hashToNodes map[common.Hash]*FilterNode // block hash => filter node
 }
 
-func NewFilterChain() FilterChain {
-	fc := FilterChain{
+func NewFilterChain() *FilterChain {
+	fc := &FilterChain{
 		hashToNodes: make(map[common.Hash]*FilterNode),
 	}
 
@@ -262,6 +262,7 @@ func (fc *FilterChain) PushBack(block *FilterBlock) *FilterNode {
 	node := &FilterNode{
 		FilterBlock: block, chain: fc,
 	}
+
 	return fc.insert(node, fc.root.prev)
 }
 

--- a/virtualfilter/chain.go
+++ b/virtualfilter/chain.go
@@ -1,0 +1,340 @@
+package virtualfilter
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/web3go/types"
+)
+
+var (
+	errRevertedBlockNotMatched  = errors.New("reverted block not matched")
+	errRewindBlockNotFound      = errors.New("rewind block not found")
+	errFilterBlockAlreadyExists = errors.New("filter block already exists")
+	errBadFilterCursor          = errors.New("bad filter cursor")
+)
+
+// parseFilterChanges parses filter chagnes to return multiple linked lists
+// of filter block grouped by `Removed` property of event log.
+func parseFilterChanges(changes *types.FilterChanges) []*list.List {
+	if len(changes.Logs) == 0 {
+		return nil
+	}
+
+	// split continuous event logs into groups by `Removed` property
+	var splitLogs [][]types.Log
+	var tmplogs []types.Log
+
+	for i := 0; i < len(changes.Logs); i++ {
+		if len(tmplogs) == 0 || tmplogs[0].Removed == changes.Logs[i].Removed {
+			tmplogs = append(tmplogs, changes.Logs[i])
+			continue
+		}
+
+		splitLogs = append(splitLogs, tmplogs)
+		tmplogs = []types.Log{changes.Logs[i]}
+	}
+
+	splitLogs = append(splitLogs, tmplogs)
+
+	// convert split logs to linked lists of filter blocks
+	blockLists := make([]*list.List, len(splitLogs))
+	for i, logs := range splitLogs {
+		blockLists[i] = list.New()
+
+		// create the head block of linked list
+		block := NewFilterBlockFromLog(&logs[0])
+		blockLists[i].PushBack(block)
+
+		for j := range logs {
+			if !block.Include(&logs[j]) { // start new block
+				block = NewFilterBlockFromLog(&logs[j])
+				blockLists[i].PushBack(block)
+			}
+
+			block.AppendLogs(logs[j])
+		}
+	}
+
+	return blockLists
+}
+
+// FilterNode chain node which wraps block and link info
+type FilterNode struct {
+	*FilterBlock
+
+	chain      *FilterChain // the chain this node belongs to
+	prev, next *FilterNode
+}
+
+// Next returns the next chain node or nil.
+func (n *FilterNode) Next() *FilterNode {
+	if p := n.next; n.chain != nil && p != &n.chain.root {
+		return p
+	}
+
+	return nil
+}
+
+// Prev returns the previous chain node or nil.
+func (n *FilterNode) Prev() *FilterNode {
+	if p := n.prev; n.chain != nil && p != &n.chain.root {
+		return p
+	}
+	return nil
+}
+
+// FilterBlock virtual filter block with event logs inside.
+type FilterBlock struct {
+	FilterCursor
+
+	reorg bool        // whether the block is re-orgnized
+	logs  []types.Log // logs contained within this block
+}
+
+func NewFilterBlockFromLog(log *types.Log) *FilterBlock {
+	return &FilterBlock{
+		FilterCursor: FilterCursor{
+			blockNum: log.BlockNumber, blockHash: log.BlockHash,
+		},
+		reorg: log.Removed,
+	}
+}
+
+func (fb *FilterBlock) AppendLogs(logs ...types.Log) {
+	fb.logs = append(fb.logs, logs...)
+}
+
+func (fb *FilterBlock) Include(log *types.Log) bool {
+	return fb.blockNum == log.BlockNumber && fb.blockHash == log.BlockHash
+}
+
+func (fb *FilterBlock) Match(block *FilterBlock) bool {
+	return fb.blockNum == block.blockNum && fb.blockHash == block.blockHash
+}
+
+// FilterChain simulates a virtual filter blockchain
+type FilterChain struct {
+	root        FilterNode                  // sentinel root node
+	genesis     *FilterNode                 // (the first) genesis chain node
+	len         int                         // canonical chain length
+	hashToNodes map[common.Hash]*FilterNode // block hash => filter node
+}
+
+func NewFilterChain() FilterChain {
+	fc := FilterChain{
+		hashToNodes: make(map[common.Hash]*FilterNode),
+	}
+
+	// init root node
+	fc.root.prev, fc.root.next = &fc.root, &fc.root
+
+	return fc
+}
+
+func (fc *FilterChain) Reorg(reverted *list.List) error {
+	rnode := fc.Back()
+
+	for ele := reverted.Front(); ele != nil; ele = ele.Next() {
+		rblock := ele.Value.(*FilterBlock)
+
+		if rnode == nil && !fc.exists(rblock.blockHash) {
+			rnode = fc.PushFront(rblock)
+		}
+
+		if rnode == nil || !rnode.Match(rblock) {
+			return errRevertedBlockNotMatched
+		}
+
+		rnode.FilterBlock = rblock
+		rnode = rnode.Prev()
+	}
+
+	// rewind the blockchain
+	return fc.Rewind(rnode)
+}
+
+func (fc *FilterChain) Extend(extended *list.List) error {
+	for ele := extended.Front(); ele != nil; ele = ele.Next() {
+		nblock := ele.Value.(*FilterBlock)
+
+		if fc.exists(nblock.blockHash) {
+			return errFilterBlockAlreadyExists
+		}
+
+		fc.PushBack(nblock)
+	}
+
+	return nil
+}
+
+type FilterChainIteratorFunc func(node *FilterNode, forkPoint bool) bool
+
+// Traverse traverses the filter chain from some specified cursor
+func (fc *FilterChain) Traverse(cursor FilterCursor, iterator FilterChainIteratorFunc) error {
+	if fc.genesis == nil { // unexploited filter chain?
+		return nil
+	}
+
+	var startNode, node *FilterNode
+
+	if cursor == nilFilterCursor {
+		// starting from genesis node if nil cursor specified
+		startNode = fc.genesis
+	} else if startNode = fc.hashToNodes[cursor.blockHash]; startNode == nil {
+		// no filter node found with the cursor
+		return errBadFilterCursor
+	}
+
+	// move backforward to the canonical chain if starting from fork chain
+	for node = startNode; node != nil && node.reorg; node = node.Prev() {
+		if !iterator(node, false) {
+			return nil
+		}
+	}
+
+	// fork chain iterated over
+	if node != startNode {
+		// iterate fork point node on the canonical chain, note it might be nil
+		// which means no intersection.
+		if !iterator(node, true) {
+			return nil
+		}
+
+		if node != nil {
+			node = node.Next()
+		} else {
+			// no intersection between the fork and canonical chain,
+			// let's start from head of the canonical chain.
+			node = fc.Front()
+		}
+	}
+
+	// move forward along the canonical chain until the end
+	for ; node != nil; node = node.Next() {
+		if !iterator(node, false) {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// Front returns the first node of the filter chain or nil if the chain is empty.
+func (fc *FilterChain) Front() *FilterNode {
+	if fc.len == 0 {
+		return nil
+	}
+
+	return fc.root.next
+}
+
+// Back returns the last node of the filter chain or nil if the chain is empty.
+func (fc *FilterChain) Back() *FilterNode {
+	if fc.len == 0 {
+		return nil
+	}
+
+	return fc.root.prev
+}
+
+// SnapshotCurrentCursor snapshots the latest cursor
+func (fc *FilterChain) SnapshotCurrentCursor() FilterCursor {
+	if tail := fc.Back(); tail != nil {
+		return tail.FilterCursor
+	}
+
+	return nilFilterCursor
+}
+
+// PushFront inserts new node at the front of the chain and returns it
+func (fc *FilterChain) PushFront(block *FilterBlock) *FilterNode {
+	node := &FilterNode{
+		FilterBlock: block, chain: fc,
+	}
+	return fc.insert(node, &fc.root)
+}
+
+// PushFront inserts new node at the back of the chain and returns it
+func (fc *FilterChain) PushBack(block *FilterBlock) *FilterNode {
+	node := &FilterNode{
+		FilterBlock: block, chain: fc,
+	}
+	return fc.insert(node, fc.root.prev)
+}
+
+// insert inserts node after at, increments fc.len, and returns the inserted node.
+func (fc *FilterChain) insert(n, at *FilterNode) *FilterNode {
+	if fc.genesis == nil {
+		fc.genesis = n
+	}
+
+	fc.hashToNodes[n.blockHash] = n
+
+	n.prev = at
+	n.next = at.next
+	n.prev.next = n
+	n.next.prev = n
+
+	fc.len++
+	return n
+}
+
+// exists checks if the filter block inserted before
+func (fc *FilterChain) exists(blockHash common.Hash) bool {
+	_, ok := fc.hashToNodes[blockHash]
+	return ok
+}
+
+// Rewind reverts the chain to the specified node
+func (fc *FilterChain) Rewind(node *FilterNode) error {
+	if node == nil { // rewind until to the root
+		fc.root.prev, fc.root.next = &fc.root, &fc.root
+		fc.len = 0
+
+		return nil
+	}
+
+	// root <-> a <-> b <-> root
+	for steps, tail := 0, fc.Back(); tail != nil; {
+		if tail == node {
+			fc.root.prev = node
+			node.next = &fc.root
+
+			fc.len -= steps
+			return nil
+		}
+
+		steps++
+		tail = tail.Prev()
+	}
+
+	return errRewindBlockNotFound
+}
+
+// print traverses the filter chain from the starting cursor, and prints the node info
+// (eg., block number, block hash etc.), mainly used for debugging.
+func (fc *FilterChain) print(cursor FilterCursor) {
+	err := fc.Traverse(cursor, func(node *FilterNode, forkPoint bool) bool {
+		var forktag string
+		if forkPoint {
+			forktag = "[fork]"
+		}
+
+		if node != nil {
+			fmt.Printf("-> #%d(%v)%v", node.blockNum, node.blockHash, forktag)
+		} else {
+			fmt.Printf("-> nil%v", forktag)
+		}
+
+		return true
+	})
+
+	if err == nil {
+		fmt.Println("->root")
+	} else {
+		fmt.Println("traversal error: ", err)
+	}
+}

--- a/virtualfilter/chain_test.go
+++ b/virtualfilter/chain_test.go
@@ -1,0 +1,148 @@
+package virtualfilter
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/web3go/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFilterChanges(t *testing.T) {
+	testcase := struct {
+		logs              []types.Log
+		expectedNumLists  int
+		expectedListSizes []int
+	}{
+		logs: []types.Log{
+			{BlockNumber: 2, BlockHash: common.HexToHash("0x12"), Removed: true},
+			{BlockNumber: 1, BlockHash: common.HexToHash("0x11"), Removed: true},
+			{BlockNumber: 1, BlockHash: common.HexToHash("0x21")},
+			{BlockNumber: 2, BlockHash: common.HexToHash("0x22")},
+			{BlockNumber: 3, BlockHash: common.HexToHash("0x23")},
+			{BlockNumber: 4, BlockHash: common.HexToHash("0x24")},
+			{BlockNumber: 4, BlockHash: common.HexToHash("0x24"), Removed: true},
+			{BlockNumber: 3, BlockHash: common.HexToHash("0x23"), Removed: true},
+			{BlockNumber: 3, BlockHash: common.HexToHash("0x33")},
+			{BlockNumber: 4, BlockHash: common.HexToHash("0x34")},
+			{BlockNumber: 5, BlockHash: common.HexToHash("0x35")},
+			{BlockNumber: 6, BlockHash: common.HexToHash("0x36")},
+		},
+		expectedNumLists:  4,
+		expectedListSizes: []int{2, 4, 2, 2},
+	}
+
+	filterBlockLists := parseFilterChanges(&types.FilterChanges{Logs: testcase.logs})
+	assert.Equal(t, testcase.expectedNumLists, len(filterBlockLists))
+
+	for i, j := 0, 0; i < len(filterBlockLists); i++ {
+		ll := filterBlockLists[i]
+		assert.Equal(t, testcase.expectedListSizes[i], ll.Len())
+
+		for node := ll.Front(); node != nil; j++ {
+			block := node.Value.(*FilterBlock)
+
+			expectedBlock := NewFilterBlockFromLog(&testcase.logs[j])
+			assert.Equal(t, expectedBlock.FilterCursor, block.FilterCursor)
+			assert.Equal(t, expectedBlock.reorg, block.reorg)
+
+			node = node.Next()
+		}
+	}
+}
+
+func TestFilterChain(t *testing.T) {
+	fchain := NewFilterChain()
+	assert.Equal(t, (*FilterNode)(nil), fchain.Front())
+	assert.Equal(t, (*FilterNode)(nil), fchain.Back())
+	assert.Equal(t, 0, fchain.len)
+
+	// test case #1 - reorg the chain
+	demoLogs1 := []types.Log{
+		{BlockNumber: 2, BlockHash: common.HexToHash("0x12"), Removed: true},
+		{BlockNumber: 1, BlockHash: common.HexToHash("0x11"), Removed: true},
+	}
+
+	fblists := parseFilterChanges(&types.FilterChanges{Logs: demoLogs1})
+	err := fchain.Reorg(fblists[0])
+	assert.NoError(t, err, "failed to reorg filter chain")
+
+	assert.Equal(t, 0, fchain.len)
+	assert.Nil(t, fchain.Front())
+	assert.Nil(t, fchain.Back())
+	assert.True(t, fchain.exists(demoLogs1[0].BlockHash))
+	assert.True(t, fchain.exists(demoLogs1[1].BlockHash))
+
+	cursor1 := FilterCursor{
+		blockNum: demoLogs1[0].BlockNumber, blockHash: demoLogs1[0].BlockHash,
+	}
+
+	i, expectedTraversalNodes := 0, []*FilterNode{
+		{FilterBlock: NewFilterBlockFromLog(&demoLogs1[0])},
+		{FilterBlock: NewFilterBlockFromLog(&demoLogs1[1])},
+		nil,
+	}
+
+	fchain.print(cursor1)
+
+	err = fchain.Traverse(cursor1, func(node *FilterNode, forkPoint bool) bool {
+		if node == nil {
+			assert.Equal(t, expectedTraversalNodes[i], node)
+		} else {
+			assert.True(t, expectedTraversalNodes[i].Match(node.FilterBlock))
+		}
+
+		i++
+		return true
+	})
+	assert.NoError(t, err, "failed to traverse filter chain")
+
+	// test case #2 - extend the chain
+	demoLogs2 := []types.Log{
+		{BlockNumber: 1, BlockHash: common.HexToHash("0x21")},
+		{BlockNumber: 2, BlockHash: common.HexToHash("0x22")},
+		{BlockNumber: 3, BlockHash: common.HexToHash("0x23")},
+		{BlockNumber: 4, BlockHash: common.HexToHash("0x24")},
+	}
+
+	fblists = parseFilterChanges(&types.FilterChanges{Logs: demoLogs2})
+	err = fchain.Extend(fblists[0])
+	assert.NoError(t, err, "failed to extend filter chain")
+
+	assert.Equal(t, len(demoLogs2), fchain.len)
+	assert.True(t, fchain.Front().Match(NewFilterBlockFromLog(&demoLogs2[0])))
+	assert.True(t, fchain.Back().Match(NewFilterBlockFromLog(&demoLogs2[len(demoLogs2)-1])))
+
+	cursor2 := FilterCursor{
+		blockNum: demoLogs2[0].BlockNumber, blockHash: demoLogs2[0].BlockHash,
+	}
+	fchain.print(cursor2)
+
+	// test case #3 - reorg && extend the chain
+	demoLogs3 := []types.Log{
+		{BlockNumber: 4, BlockHash: common.HexToHash("0x24"), Removed: true},
+		{BlockNumber: 3, BlockHash: common.HexToHash("0x23"), Removed: true},
+	}
+
+	fblists = parseFilterChanges(&types.FilterChanges{Logs: demoLogs3})
+	err = fchain.Reorg(fblists[0])
+	assert.NoError(t, err, "failed to reorg filter chain")
+
+	cursor3 := FilterCursor{
+		blockNum: demoLogs3[1].BlockNumber, blockHash: demoLogs3[1].BlockHash,
+	}
+	fchain.print(cursor3)
+
+	demoLogs4 := []types.Log{
+		{BlockNumber: 3, BlockHash: common.HexToHash("0x33")},
+		{BlockNumber: 4, BlockHash: common.HexToHash("0x34")},
+		{BlockNumber: 5, BlockHash: common.HexToHash("0x35")},
+		{BlockNumber: 6, BlockHash: common.HexToHash("0x36")},
+	}
+
+	fblists = parseFilterChanges(&types.FilterChanges{Logs: demoLogs4})
+	err = fchain.Extend(fblists[0])
+	assert.NoError(t, err, "failed to extend filter chain")
+
+	fchain.print(cursor3)
+}

--- a/virtualfilter/filter.go
+++ b/virtualfilter/filter.go
@@ -29,6 +29,8 @@ const (
 
 var (
 	errFilterNotFound = errors.New("filter not found")
+
+	nilFilterCursor = FilterCursor{}
 )
 
 // Filter is a helper struct that holds meta information over the filter type,
@@ -79,7 +81,7 @@ func IsFilterNotFoundError(err error) bool {
 
 // FilterCursor the visiting position where last polling ends.
 type FilterCursor struct {
-	blockNum  rpc.BlockNumber
+	blockNum  uint64
 	blockHash common.Hash
 }
 

--- a/virtualfilter/proxy.go
+++ b/virtualfilter/proxy.go
@@ -29,30 +29,31 @@ type proxyContext struct {
 	// shared proxy filter ID
 	fid ProxyFilterID
 
-	// current polling cursor
-	cur FilterCursor
-
 	// delegate filters
 	delegates map[DelegateFilterID]*FilterContext
+
+	// simulated filter blockchain
+	chain FilterChain
 }
 
 func newProxyContext(fid ProxyFilterID) proxyContext {
 	return proxyContext{
 		fid:       fid,
 		delegates: make(map[web3rpc.ID]*FilterContext),
+		chain:     NewFilterChain(),
 	}
 }
 
 type proxyStub struct {
+	proxyContext
 	mu     sync.Mutex
 	obs    proxyObserver
 	client *node.Web3goClient
-	pctx   proxyContext
 }
 
 func newProxyStub(obs proxyObserver, client *node.Web3goClient) *proxyStub {
 	return &proxyStub{
-		obs: obs, client: client, pctx: nilProxyContext,
+		proxyContext: nilProxyContext, obs: obs, client: client,
 	}
 }
 
@@ -68,9 +69,9 @@ func (p *proxyStub) newFilter(crit *types.FilterQuery) (*web3rpc.ID, error) {
 	// new virtual delegate filter
 	dfid := web3rpc.NewID()
 
-	// snapshot shared filter cursor
-	p.pctx.delegates[dfid] = &FilterContext{
-		cursor: p.pctx.cur, crit: crit,
+	// snapshot the tail cursor of the filter chain
+	p.delegates[dfid] = &FilterContext{
+		crit: crit, cursor: p.chain.SnapshotCurrentCursor(),
 	}
 
 	return &dfid, nil
@@ -80,19 +81,65 @@ func (p *proxyStub) uninstallFilter(id DelegateFilterID) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if _, ok := p.pctx.delegates[id]; !ok {
+	if _, ok := p.delegates[id]; !ok {
 		return false
 	}
 
-	delete(p.pctx.delegates, id)
+	delete(p.delegates, id)
 	return true
+}
+
+// TODO: get change logs from db store
+func (p *proxyStub) getFilterChanges(id DelegateFilterID) (*types.FilterChanges, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	fctx, ok := p.delegates[id]
+	if !ok {
+		return nil, errFilterNotFound
+	}
+
+	var res types.FilterChanges
+
+	err := p.chain.Traverse(fctx.cursor, func(node *FilterNode, forkPoint bool) bool {
+		if node == nil { // skip nil node
+			return true
+		}
+
+		if fctx.cursor == nilFilterCursor { // full traversal for nil cursor
+			res.Logs = append(res.Logs, node.logs...)
+			return true
+		}
+
+		// otherwise for non-nil cursor
+
+		if forkPoint { // ignore fork point
+			return true
+		}
+
+		// skip node at the filter cursor, whose block is not re-organized
+		if fctx.cursor == node.FilterCursor && !node.reorg {
+			return true
+		}
+
+		res.Logs = append(res.Logs, node.logs...)
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// update the filter cursor
+	fctx.cursor = p.chain.SnapshotCurrentCursor()
+	return &res, nil
 }
 
 func (p *proxyStub) getFilterContext(id DelegateFilterID) (*FilterContext, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	fctx, ok := p.pctx.delegates[id]
+	fctx, ok := p.delegates[id]
 	return fctx, ok
 }
 
@@ -108,32 +155,78 @@ func (p *proxyStub) poll() {
 			return
 		}
 
-		fchanges, err := p.client.Filter.GetFilterChanges(p.pctx.fid)
-		if err == nil {
-			lastPollingTime = time.Now() // update last polling time
-			p.merge(fchanges)
-			continue
-		}
-
-		// Proxy filter not found by full node? this may be due to full node reboot.
-		if IsFilterNotFoundError(err) {
-			p.close()
-			return
-		}
-
-		if dur := time.Since(lastPollingTime); dur > maxPollingDelayDuration { // too many times delayed?
-			logrus.WithFields(logrus.Fields{
-				"proxyFilterID": p.pctx.fid, "delayedDuration": dur,
-			}).WithError(err).Error("Filter proxy failed to poll filter changes after too many delays")
-
+		if !p.pollOnce(&lastPollingTime) {
 			p.close()
 			return
 		}
 	}
 }
 
-func (p *proxyStub) merge(changes *types.FilterChanges) {
-	// TODO: merge filter changes to db && cache store
+func (p *proxyStub) pollOnce(lastPollingTime *time.Time) bool {
+	fchanges, err := p.client.Filter.GetFilterChanges(p.fid)
+	if err != nil {
+		// proxy filter not found by full node? this may be due to full node reboot.
+		if IsFilterNotFoundError(err) {
+			return false
+		}
+
+		duration := time.Since(*lastPollingTime)
+		if duration < maxPollingDelayDuration { // retry
+			return true
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"proxyFullNode":   p.client.URL,
+			"proxyContext":    p.proxyContext,
+			"delayedDuration": duration,
+		}).WithError(err).Error("Filter proxy failed to poll filter changes due to too long delays")
+		return false
+	}
+
+	// merge the filter changes
+	if err = p.merge(fchanges); err != nil {
+		logrus.WithFields(logrus.Fields{
+			"proxyFullNode": p.client.URL,
+			"proxyContext":  p.proxyContext,
+		}).WithError(err).Error("Filter proxy failed to merge filter changes")
+		return false
+	}
+
+	// update polling time
+	*lastPollingTime = time.Now()
+	return true
+}
+
+// TODO:
+// 1. prune filter change logs from memory in case of memory blast;
+// 2. store filter change logs within db store for better reliability.
+func (p *proxyStub) merge(changes *types.FilterChanges) error {
+	chainedBlocksList := parseFilterChanges(changes)
+	if len(chainedBlocksList) == 0 {
+		return nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// update the virtual filter blockchain
+	for i := range chainedBlocksList {
+		if head := chainedBlocksList[i].Front(); head.Value.(*FilterBlock).reorg {
+			// reorg the chain
+			if err := p.chain.Reorg(chainedBlocksList[i]); err != nil {
+				return errors.WithMessage(err, "failed to reorg filter chain")
+			}
+
+			continue
+		}
+
+		// extend the chain
+		if err := p.chain.Extend(chainedBlocksList[i]); err != nil {
+			return errors.WithMessage(err, "failed to extend filter chain")
+		}
+	}
+
+	return nil
 }
 
 // close closes the proxy so that new shared proxy filter can be recreated
@@ -143,17 +236,17 @@ func (p *proxyStub) close(lockfree ...bool) {
 		defer p.mu.Unlock()
 	}
 
-	if p.pctx.fid != nilRpcId {
+	if p.fid != nilRpcId {
 		// uninstall the proxy filter with error ignored
-		p.client.Filter.UninstallFilter(p.pctx.fid)
+		p.client.Filter.UninstallFilter(p.fid)
 	}
 
 	if p.obs != nil {
-		p.obs.onClosed(p.pctx)
+		p.obs.onClosed(p.proxyContext)
 	}
 
 	// reset proxy context
-	p.pctx = nilProxyContext
+	p.proxyContext = nilProxyContext
 }
 
 // gc closes the proxy if not under use by any delegate filter
@@ -161,7 +254,7 @@ func (p *proxyStub) gc() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if len(p.pctx.delegates) == 0 {
+	if len(p.delegates) == 0 {
 		p.close(true)
 		return true
 	}
@@ -171,7 +264,7 @@ func (p *proxyStub) gc() bool {
 
 // establishes a new shared filter to full node if necessary
 func (p *proxyStub) establish() error {
-	if p.pctx.fid != nilRpcId { // already established
+	if p.fid != nilRpcId { // already established
 		return nil
 	}
 
@@ -181,10 +274,10 @@ func (p *proxyStub) establish() error {
 		return err
 	}
 
-	p.pctx = newProxyContext(*fid)
+	p.proxyContext = newProxyContext(*fid)
 
 	if p.obs != nil {
-		p.obs.onEstablished(p.pctx)
+		p.obs.onEstablished(p.proxyContext)
 	}
 
 	// start polling from full node instantly

--- a/virtualfilter/proxy.go
+++ b/virtualfilter/proxy.go
@@ -33,7 +33,7 @@ type proxyContext struct {
 	delegates map[DelegateFilterID]*FilterContext
 
 	// simulated filter blockchain
-	chain FilterChain
+	chain *FilterChain
 }
 
 func newProxyContext(fid ProxyFilterID) proxyContext {


### PR DESCRIPTION
1. merge instantly polled changed logs into a memory virtual filter chain;
2. assemble changed logs from virtual filter chain in memory to serve `eth_getFilterChanges`;
3. filter changed logs according to filter criterion provided when new filter created.

TODO:
1. add prune support for virtual filter chain in case of memory blast;
2. persist filter changes logs to db for more reliability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/confura/50)
<!-- Reviewable:end -->
