### PR TITLE
Use LRU cache to evict virtual filter block full of event logs

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -303,9 +303,11 @@ node:
 #     # parity RPC
 #     - parity_getBlockReceipts
 
-# Virtual filters configurations
-virtualFilters:
-  # Served HTTP endpoint
-  endpoint: ":48545"
-  # Time to live for inactive filter
-  TTL: 1m
+# # Virtual filters configurations
+# virtualFilters:
+#   # Served HTTP endpoint
+#   endpoint: ":48545"
+#   # Time to live for inactive filter
+#   TTL: 1m
+#   # Max number of filter blocks full of event logs to restrict memory usage
+#   MaxFullFilterBlocks: 100

--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -254,7 +254,10 @@ func (vfls *VirtualFilterLogStore) GetLogs(
 		// convert to web3go log type
 		for _, v := range logs {
 			var w3log w3types.Log
-			util.MustUnmarshalJson(v.JsonRepr, &w3log)
+			if err := json.Unmarshal(v.JsonRepr, &w3log); err != nil {
+				return nil, errors.WithMessage(err, "invalid event log json")
+			}
+
 			result = append(result, w3log)
 		}
 

--- a/virtualfilter/config.go
+++ b/virtualfilter/config.go
@@ -10,6 +10,8 @@ import (
 type Config struct {
 	Endpoint string        `default:":48545"` // server listening endpoint (default: :48545)
 	TTL      time.Duration `default:":1m"`    // how long filters stay active (default: 1min)
+	// max number of filter blocks full of event logs to restrict memory usage (default: 100)
+	MaxFullFilterBlocks int `default:"100"`
 }
 
 func mustNewConfigFromViper() *Config {

--- a/virtualfilter/filter_system.go
+++ b/virtualfilter/filter_system.go
@@ -182,7 +182,7 @@ func (fs *FilterSystem) loadOrNewFnProxy(client *node.Web3goClient) *proxyStub {
 	nn := client.NodeName()
 
 	v, _ := fs.fnProxies.LoadOrStoreFn(nn, func(interface{}) interface{} {
-		return newProxyStub(fs, client)
+		return newProxyStub(fs.cfg, fs, client)
 	})
 
 	return v.(*proxyStub)


### PR DESCRIPTION
to restrict memory usage of virtual filter service

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/confura/52)
<!-- Reviewable:end -->
