### PR TITLE
Disable gzip due to potential memory leak

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/openweb3/web3go v0.2.5
 	github.com/pkg/errors v0.9.1
 	github.com/royeo/dingrobot v1.0.1-0.20191230075228-c90a788ca8fd
+	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.10.0

--- a/util/rpc/rpc_stack.go
+++ b/util/rpc/rpc_stack.go
@@ -1,0 +1,142 @@
+package rpc
+
+import (
+	"compress/gzip"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/rs/cors"
+)
+
+type httpHandlerMiddleware func(next http.Handler) http.Handler
+
+// NewHTTPHandlerStack returns wrapped http-related handlers
+func NewHTTPHandlerStack(srv http.Handler, chains ...httpHandlerMiddleware) http.Handler {
+	for i := 0; i < len(chains); i++ {
+		srv = chains[i](srv)
+	}
+
+	return srv
+}
+
+func WithCorsHandler(allowedOrigins []string) httpHandlerMiddleware {
+	return func(next http.Handler) http.Handler {
+		return newCorsHandler(next, allowedOrigins)
+	}
+}
+
+func WithVHostHandler(vhosts []string) httpHandlerMiddleware {
+	return func(next http.Handler) http.Handler {
+		return newVHostHandler(vhosts, next)
+	}
+}
+
+func WithGzipHandler() httpHandlerMiddleware {
+	return func(next http.Handler) http.Handler {
+		return newGzipHandler(next)
+	}
+}
+
+func newCorsHandler(srv http.Handler, allowedOrigins []string) http.Handler {
+	// disable CORS support if user has not specified a custom CORS configuration
+	if len(allowedOrigins) == 0 {
+		return srv
+	}
+	c := cors.New(cors.Options{
+		AllowedOrigins: allowedOrigins,
+		AllowedMethods: []string{http.MethodPost, http.MethodGet},
+		AllowedHeaders: []string{"*"},
+		MaxAge:         600,
+	})
+	return c.Handler(srv)
+}
+
+// virtualHostHandler is a handler which validates the Host-header of incoming requests.
+// Using virtual hosts can help prevent DNS rebinding attacks, where a 'random' domain name points to
+// the service ip address (but without CORS headers). By verifying the targeted virtual host, we can
+// ensure that it's a destination that the node operator has defined.
+type virtualHostHandler struct {
+	vhosts map[string]struct{}
+	next   http.Handler
+}
+
+func newVHostHandler(vhosts []string, next http.Handler) http.Handler {
+	vhostMap := make(map[string]struct{})
+	for _, allowedHost := range vhosts {
+		vhostMap[strings.ToLower(allowedHost)] = struct{}{}
+	}
+	return &virtualHostHandler{vhostMap, next}
+}
+
+// ServeHTTP serves JSON-RPC requests over HTTP, implements http.Handler
+func (h *virtualHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// if r.Host is not set, we can continue serving since a browser would set the Host header
+	if r.Host == "" {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+	host, _, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		// Either invalid (too many colons) or no port specified
+		host = r.Host
+	}
+	if ipAddr := net.ParseIP(host); ipAddr != nil {
+		// It's an IP address, we can serve that
+		h.next.ServeHTTP(w, r)
+		return
+
+	}
+	// Not an IP address, but a hostname. Need to validate
+	if _, exist := h.vhosts["*"]; exist {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+	if _, exist := h.vhosts[host]; exist {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+	http.Error(w, "invalid host specified", http.StatusForbidden)
+}
+
+var gzPool = sync.Pool{
+	New: func() interface{} {
+		w := gzip.NewWriter(io.Discard)
+		return w
+	},
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w *gzipResponseWriter) WriteHeader(status int) {
+	w.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func newGzipHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Encoding", "gzip")
+
+		gz := gzPool.Get().(*gzip.Writer)
+		defer gzPool.Put(gz)
+
+		gz.Reset(w)
+		defer gz.Close()
+
+		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
+	})
+}

--- a/util/rpc/server.go
+++ b/util/rpc/server.go
@@ -52,11 +52,7 @@ func MustNewServer(name string, rpcs map[string]interface{}, middlewares ...hand
 	}).Info("RPC server APIs registered")
 
 	httpServer := http.Server{
-		Handler: NewHTTPHandlerStack(
-			handler,
-			WithCorsHandler([]string{"*"}),
-			WithVHostHandler([]string{"*"}),
-		),
+		Handler: newHTTPHandlerStack(handler, []string{"*"}, []string{"*"}),
 	}
 
 	viper.SetDefault("rpc.wsPingInterval", defaultWsPingInterval)

--- a/util/rpc/server.go
+++ b/util/rpc/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/Conflux-Chain/confura/util/rpc/handlers"
-	"github.com/ethereum/go-ethereum/node"
 	"github.com/openweb3/go-rpc-provider"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -53,7 +52,11 @@ func MustNewServer(name string, rpcs map[string]interface{}, middlewares ...hand
 	}).Info("RPC server APIs registered")
 
 	httpServer := http.Server{
-		Handler: node.NewHTTPHandlerStack(handler, []string{"*"}, []string{"*"}),
+		Handler: NewHTTPHandlerStack(
+			handler,
+			WithCorsHandler([]string{"*"}),
+			WithVHostHandler([]string{"*"}),
+		),
 	}
 
 	viper.SetDefault("rpc.wsPingInterval", defaultWsPingInterval)


### PR DESCRIPTION
There is a potential [memory leak](https://github.com/gin-contrib/gzip/issues/26) for stdlib `compress/flate.NewWriter`, so disable gzip for our rpc server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/154)
<!-- Reviewable:end -->
