### PR TITLE
Add route benchmark testing for node manager pool

### DIFF
--- a/node/pool_test.go
+++ b/node/pool_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	groupNodeUrls = map[Group][]string{
+	testGroupNodeUrls = map[Group][]string{
 		"cfxfilter": {
 			"http://127.0.0.1:25372",
 		},
@@ -46,7 +46,7 @@ func BenchmarkNodePoolRoute(b *testing.B) {
 	})
 
 	var groups []Group
-	for grp, urls := range groupNodeUrls {
+	for grp, urls := range testGroupNodeUrls {
 		pool.add(grp, urls...)
 		groups = append(groups, grp)
 	}

--- a/node/pool_test.go
+++ b/node/pool_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -34,11 +33,7 @@ type dummyNode struct {
 }
 
 func newDummyNode(group Group, name, url string, hm HealthMonitor) (*dummyNode, error) {
-	_, cancel := context.WithCancel(context.Background())
-	n := &dummyNode{newBaseNode(name, url, cancel)}
-
-	n.atomicStatus.Store(NewStatus(group, name))
-	return n, nil
+	return &dummyNode{newBaseNode(name, url, nil)}, nil
 }
 
 func (n *dummyNode) LatestEpochNumber() (uint64, error) {

--- a/node/pool_test.go
+++ b/node/pool_test.go
@@ -1,0 +1,80 @@
+package node
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var (
+	groupNodeUrls = map[Group][]string{
+		"cfxfilter": {
+			"http://127.0.0.1:25372",
+		},
+		"cfxhttp": {
+			"http://127.0.0.1:25373",
+			"http://127.0.0.1:25374",
+			"http://127.0.0.1:25375",
+		},
+		"cfxlog": {
+			"http://127.0.0.1:25372",
+		},
+		"cfxws": {
+			"ws://127.0.0.1:25351",
+			"ws://127.0.0.1:25352",
+			"ws://127.0.0.1:25353",
+		},
+	}
+)
+
+type dummyNode struct {
+	*baseNode
+}
+
+func newDummyNode(group Group, name, url string, hm HealthMonitor) (*dummyNode, error) {
+	_, cancel := context.WithCancel(context.Background())
+	n := &dummyNode{newBaseNode(name, url, cancel)}
+
+	n.atomicStatus.Store(NewStatus(group, name))
+	return n, nil
+}
+
+func (n *dummyNode) LatestEpochNumber() (uint64, error) {
+	panic("not supported")
+}
+
+func BenchmarkNodePoolRoute(b *testing.B) {
+	pool := newNodePool(func(group Group, name, url string, hm HealthMonitor) (Node, error) {
+		return newDummyNode(group, name, url, hm)
+	})
+
+	var groups []Group
+	for grp, urls := range groupNodeUrls {
+		pool.add(grp, urls...)
+		groups = append(groups, grp)
+	}
+
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	b.ResetTimer()
+
+	// run the `manager.Route` function b.N times
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		grp := groups[rnd.Intn(len(groups))]
+		key := strconv.Itoa(rnd.Intn(b.N))
+		b.StartTimer()
+
+		mgr, ok := pool.manager(grp)
+		if !ok {
+			b.Fatal("group not registered")
+		}
+
+		url := mgr.Route([]byte(key))
+		if len(url) == 0 {
+			b.Fatal("route empty url")
+		}
+	}
+}


### PR DESCRIPTION
on personal mac pro:
```
go test -benchmem -run=^$ -bench ^BenchmarkNodePoolRoute$ [github.com/Conflux-Chain/confura/node](http://github.com/Conflux-Chain/confura/node) -cpu=2,4,8,16                                       
goos: darwin
goarch: amd64
pkg: [github.com/Conflux-Chain/confura/node](http://github.com/Conflux-Chain/confura/node)
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkNodePoolRoute-2          464599              2640 ns/op             212 B/op          9 allocs/op
BenchmarkNodePoolRoute-4          416289              2600 ns/op             212 B/op          9 allocs/op
BenchmarkNodePoolRoute-8          490120              2458 ns/op             212 B/op          9 allocs/op
BenchmarkNodePoolRoute-16         467149              2399 ns/op             212 B/op          9 allocs/op
PASS
ok      [github.com/Conflux-Chain/confura/node](http://github.com/Conflux-Chain/confura/node)   116.458s
```

on linux server:
```
go test -benchmem -run=^$ -bench ^BenchmarkNodePoolRoute$ github.com/Conflux-Chain/confura/node -cpu=2,4,8
goos: linux
goarch: amd64
pkg: github.com/Conflux-Chain/confura/node
cpu: AMD EPYC 7T83 64-Core Processor
BenchmarkNodePoolRoute-2   	  686862	      1606 ns/op	     212 B/op	       9 allocs/op
BenchmarkNodePoolRoute-4   	  855673	      1593 ns/op	     212 B/op	       9 allocs/op
BenchmarkNodePoolRoute-8   	  873684	      1657 ns/op	     212 B/op	       9 allocs/op
PASS
ok  	github.com/Conflux-Chain/confura/node	32.191s
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/160)
<!-- Reviewable:end -->
