### PR TITLE
Deprecate the implicit use of `init` functions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,14 @@ package config
 import (
 	"strings"
 
+	"github.com/Conflux-Chain/confura/node"
+	"github.com/Conflux-Chain/confura/rpc"
+	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/util/alert"
+	"github.com/Conflux-Chain/confura/util/blacklist"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/Conflux-Chain/confura/util/pprof"
+	rpcutil "github.com/Conflux-Chain/confura/util/rpc"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/pkg/errors"
@@ -29,9 +34,18 @@ func init() {
 	// init pprof
 	pprof.MustInit()
 	// init metrics
-	metrics.Init()
+	metrics.MustInit()
 	// init alert
 	alert.InitDingRobot()
+	// init misc util
+	rpcutil.MustInit()
+	blacklist.MustInit()
+	// init store
+	store.MustInit()
+	// init node
+	node.MustInit()
+	// init rpc
+	rpc.MustInit()
 }
 
 func initLogger() {

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 // eg., `INFURA_LOG_LEVEL` will override "log.level" config item from the config file.
 const viperEnvPrefix = "infura"
 
-func init() {
+func Init() {
 	// init viper
 	viper.MustInit(viperEnvPrefix)
 	// init logger

--- a/config/version.go
+++ b/config/version.go
@@ -11,14 +11,9 @@ var (
 	GitCommit string
 
 	BuildDate string
-	BuildOS   string
-	BuildArch string
-)
-
-func init() {
-	BuildOS = runtime.GOOS
+	BuildOS   = runtime.GOOS
 	BuildArch = runtime.GOARCH
-}
+)
 
 func DumpVersionInfo() {
 	strFormat := "%-12v%v\n"

--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/confura/cmd"
+	"github.com/Conflux-Chain/confura/config"
 )
 
 func main() {
+	// ensure configuration initialized at first.
+	config.Init()
+
 	cmd.Execute()
 }

--- a/node/config.go
+++ b/node/config.go
@@ -3,9 +3,6 @@ package node
 import (
 	"time"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/buraksezer/consistent"
 	"github.com/sirupsen/logrus"
@@ -17,7 +14,7 @@ var cfg config
 var urlCfg map[Group]UrlConfig
 var ethUrlCfg map[Group]UrlConfig
 
-func init() {
+func MustInit() {
 	viper.MustUnmarshalKey("node", &cfg)
 	logrus.WithField("config", cfg).Debug("Node manager configurations loaded.")
 

--- a/rpc/metrics.go
+++ b/rpc/metrics.go
@@ -11,7 +11,7 @@ const (
 	metricPrefixInfura = "infura/"
 )
 
-func init() {
+func initMetrics() {
 	// Remove unused metrics imported from ethereum rpc package
 	var names []string
 	for k := range metrics.DefaultRegistry.GetAll() {

--- a/rpc/server_middleware.go
+++ b/rpc/server_middleware.go
@@ -18,9 +18,12 @@ const (
 	ctxKeyClientGroup    = handlers.CtxKey("Infura-RPC-Client-Group")
 )
 
-// go-rpc-provider only supports static middlewares for RPC server.
 func MustInit() {
-	// middlewares executed in order
+	// init metrics
+	initMetrics()
+
+	// Register middlewares for go-rpc-provider, which only supports static middlewares for RPC server.
+	// The following middlewares are executed in order.
 
 	// panic recovery
 	rpc.HookHandleCallMsg(middlewares.Recover)

--- a/rpc/server_middleware.go
+++ b/rpc/server_middleware.go
@@ -19,7 +19,7 @@ const (
 )
 
 // go-rpc-provider only supports static middlewares for RPC server.
-func init() {
+func MustInit() {
 	// middlewares executed in order
 
 	// panic recovery

--- a/store/log_filter.go
+++ b/store/log_filter.go
@@ -3,9 +3,6 @@ package store
 import (
 	"time"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/go-conflux-sdk/types"
 	"github.com/Conflux-Chain/go-conflux-sdk/types/cfxaddress"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
@@ -46,7 +43,7 @@ var ( // Log filter constants
 	MaxLogBlockRange uint64
 )
 
-func init() {
+func initLogFilter() {
 	var lfc struct {
 		MaxBlockHashCount int `default:"32"`
 		MaxAddressCount   int `default:"32"`

--- a/store/store.go
+++ b/store/store.go
@@ -5,9 +5,6 @@ import (
 	"io"
 	"strings"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/go-conflux-sdk/types"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/sirupsen/logrus"
@@ -167,7 +164,9 @@ func (conf *storeConfig) IsDisabledForType(edt EpochDataType) bool {
 	return false
 }
 
-func init() {
+func MustInit() {
 	cfxStoreConfig.mustInit("store")
 	ethStoreConfig.mustInit("ethstore")
+
+	initLogFilter()
 }

--- a/util/blacklist/contract_addr.go
+++ b/util/blacklist/contract_addr.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/go-conflux-sdk/types/cfxaddress"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -24,7 +21,7 @@ type BlacklistedAddrInfo struct {
 	Epoch uint64
 }
 
-func init() {
+func MustInit() {
 	// Load blacklisted contract address.
 	var blackListAddrStrs string
 	if err := viper.UnmarshalKey("sync.blackListAddrs", &blackListAddrStrs); err != nil {

--- a/util/metrics/report.go
+++ b/util/metrics/report.go
@@ -14,7 +14,7 @@ import (
 // metric created for static variables in any package.
 //
 // In addition, this package should be imported after the initialization of viper and logrus.
-func Init() {
+func MustInit() {
 	var config struct {
 		Enabled  bool `default:"true"`
 		Influxdb struct {

--- a/util/rpc/config.go
+++ b/util/rpc/config.go
@@ -3,9 +3,6 @@ package rpc
 import (
 	"time"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 )
 
@@ -86,7 +83,7 @@ func WithCircuitBreaker(maxFail int, failTimeWindow, openColdTime time.Duration)
 	}
 }
 
-func init() {
+func MustInit() {
 	viper.MustUnmarshalKey("cfx", &cfxClientCfg)
 	viper.MustUnmarshalKey("eth", &ethClientCfg)
 }

--- a/util/rpc/middlewares/web3pay.go
+++ b/util/rpc/middlewares/web3pay.go
@@ -3,9 +3,6 @@ package middlewares
 import (
 	"strings"
 
-	// ensure viper based configuration initialized at the very beginning
-	_ "github.com/Conflux-Chain/confura/config"
-
 	"github.com/Conflux-Chain/confura/util/rpc/handlers"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	web3pay "github.com/Conflux-Chain/web3pay-service/client"


### PR DESCRIPTION
The implicit use of `init` functions can lead to unpredictability and bugs. Therefore, we recommend avoiding this practice. Instead, consider using explicit initialization methods for better clarity and maintainability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/173)
<!-- Reviewable:end -->
