### PR TITLE
HA sync support with leader/follower election

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Confura is comprised of serveral components as below:
 
 ### Blockchain Sync
 
-You can use the `sync` subcommand to start sync service, including DB/ETH sync as well as fast catchup.
+You can use the `sync` subcommand to start sync service, including DB and ETH sync.
 
 > Usage:
 >   confura sync [flags]
@@ -114,11 +114,6 @@ You can use the `sync` subcommand to start sync service, including DB/ETH sync a
 >
 >       --db           start core space DB sync server
 >       --eth          start ETH sync server
->       --catchup      start core space fast catchup server
->       --adaptive     automatically adjust target epoch number to the latest stable epoch
->       --benchmark    benchmarking the performance during fast catch-up sync (default true)
->       --start uint   the epoch from which fast catch-up sync will start
->       --end uint     the epoch until which fast catch-up sync will end
 >       --help         help for sync
 
 eg., you can run the following to kick off synchronizing core space blockchain data into database:

--- a/store/mysql/config.go
+++ b/store/mysql/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Conflux-Chain/go-conflux-util/dlock"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	gosql "github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ var allModels = []interface{}{
 	&epochBlockMap{},
 	&bnPartition{},
 	&NodeRoute{},
+	&dlock.Dlock{},
 }
 
 // Config represents the mysql configurations to open a database instance.

--- a/store/mysql/store_common.go
+++ b/store/mysql/store_common.go
@@ -16,6 +16,10 @@ func newBaseStore(db *gorm.DB) *baseStore {
 	return &baseStore{db}
 }
 
+func (bs *baseStore) DB() *gorm.DB {
+	return bs.db
+}
+
 func (baseStore) IsRecordNotFound(err error) bool {
 	return errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, store.ErrNotFound)
 }

--- a/store/types.go
+++ b/store/types.go
@@ -48,6 +48,7 @@ var (
 	ErrContinousEpochRequired = errors.New("continous epoch required")
 	ErrAlreadyPruned          = errors.New("data already pruned")
 	ErrChainReorged           = errors.New("chain re-orged")
+	ErrLeaderRenewal          = errors.New("leadership renewal failure")
 
 	// operationable epoch data types
 	OpEpochDataTypes = []EpochDataType{

--- a/sync/epoch_pivot_test.go
+++ b/sync/epoch_pivot_test.go
@@ -34,7 +34,7 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	assert.False(t, w.isSet())
 
 	// test push
-	err := w.push(&types.Block{
+	err := w.Push(&types.Block{
 		BlockHeader: types.BlockHeader{
 			EpochNumber: (*hexutil.Big)(big.NewInt(0)),
 			ParentHash:  "",
@@ -47,7 +47,7 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	assert.Equal(t, uint64(0), w.epochTo)
 	assert.True(t, w.isSet())
 
-	err = w.push(&types.Block{
+	err = w.Push(&types.Block{
 		BlockHeader: types.BlockHeader{
 			EpochNumber: (*hexutil.Big)(big.NewInt(1)),
 			ParentHash:  "epoch0",
@@ -60,7 +60,7 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	assert.Equal(t, uint64(1), w.epochTo)
 
 	// test push error - mismatched parent hash
-	err = w.push(&types.Block{
+	err = w.Push(&types.Block{
 		BlockHeader: types.BlockHeader{
 			EpochNumber: (*hexutil.Big)(big.NewInt(2)),
 			ParentHash:  "epoch1`",
@@ -71,7 +71,7 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	t.Logf("push error: %v", err)
 
 	// test push error - incontinuous epoch
-	err = w.push(&types.Block{
+	err = w.Push(&types.Block{
 		BlockHeader: types.BlockHeader{
 			EpochNumber: (*hexutil.Big)(big.NewInt(20)),
 			ParentHash:  "epoch1",
@@ -82,7 +82,7 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	t.Logf("push error: %v", err)
 
 	// test auto reclaim over capacity on push
-	err = w.push(&types.Block{
+	err = w.Push(&types.Block{
 		BlockHeader: types.BlockHeader{
 			EpochNumber: (*hexutil.Big)(big.NewInt(2)),
 			ParentHash:  "epoch1",
@@ -95,22 +95,22 @@ func TestEpochPivotWindowPushPop(t *testing.T) {
 	assert.Equal(t, uint64(2), w.epochTo)
 
 	// test getPivotHash
-	ph, ok := w.getPivotHash(0)
+	ph, ok := w.GetPivotHash(0)
 	assert.False(t, ok)
 	assert.NotEqual(t, "epoch0", string(ph))
 
-	ph, _ = w.getPivotHash(1)
+	ph, _ = w.GetPivotHash(1)
 	assert.Equal(t, "epoch1", string(ph))
 
-	ph, _ = w.getPivotHash(2)
+	ph, _ = w.GetPivotHash(2)
 	assert.Equal(t, "epoch2", string(ph))
 
 	// test pop empty
-	w.popn(3)
+	w.Popn(3)
 	assert.Equal(t, uint32(2), w.size())
 
 	// test pop underflow
-	w.popn(0)
+	w.Popn(0)
 	assert.Equal(t, uint32(0), w.size())
 	assert.False(t, w.isSet())
 }


### PR DESCRIPTION
- **LeaderManager Integration**: 
Integrated `LeaderManager` with both corespace and espace database syncers to enable high availability and seamless leader election processes.
- **Catch-Up Command Deprecation**: 
Removed the catch-up subcommand to simplify synchronization logic. Also updated documentation to reflect these changes.
- **Finalizer Cutpoint Addition**: 
Introduced a `finalizer` cutpoint immediately before the final transaction execution, which ensures reliable store push/pop operations by maintaining a consistent state during these critical phases.
- **Concurrency Enhancement**: 
Added concurrency support to the epoch pivot sliding window mechanism.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/183)
<!-- Reviewable:end -->
