### PR TITLE
Implement expirable LRU cache and config settings for EVM calls

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -410,24 +410,41 @@ node:
 #     # Exposed RPC endpoint of virtual filter service for client request
 #     serviceRpcUrl: http://127.0.0.1:42537
 
-# # Global constraints
-# constraints:
-#   # Log filter constraint
-#   logfilter:
-#     # Maximum count of block hashes
+# # Request control Configuration
+# requestControl:
+#   # Log filter limits for handling 'getLogs' requests
+#   logFilter:
+#   # Maximum number of block hashes allowed in a filter
 #     maxBlockHashCount: 32
-#     # Maximum count of address
+#     # Maximum number of addresses allowed in a filter
 #     maxAddressCount: 32
-#     # Maximum count of topics
+#     # Maximum number of topics allowed in a filter
 #     maxTopicCount: 32
-#     # Maximum epoch range for the log filter split to the full node
+#     # Maximum epoch range to split log filters for full nodes
 #     maxSplitEpochRange: 1000
-#     # Maximum block range for the log filter split to the full node
+#     # Maximum block range to split log filters for full nodes
 #     maxSplitBlockRange: 1000
-#   # RPC handler
-#   rpc:
-#     # Maximum number of bytes for the response body of getLogs requests
-#     maxGetLogsResponseBytes: 10 * 1024 * 1024
+#
+#   # Resource usage constraints
+#   resourceLimits:
+#     # Maximum response size for 'getLogs' requests (default 10MB)
+#     maxGetLogsResponseSize: 10485760
+#
+#   # ETH Cache settings
+#   ethCache:
+#     # Cache expiration time duration for 'net_version' requests
+#     netVersionExpiration: 1m
+#     # Cache expiration time duration for 'eth_clientVersion' requests
+#     clientVersionExpiration: 1m
+#     # Cache expiration time duration for 'eth_chainId' requests
+#     chainIdExpiration: 8760h
+#     # Cache expiration time duration for 'eth_blockNumber'equests
+#     blockNumberExpiration: 1s
+#     # Cache expiration time duration for 'eth_gasPrice'
+#     priceExpiration: 3s
+#     # LRU Cache size and expiration time duration for 'eth_call'
+#     callCacheExpiration: 1s
+#     callCacheSize: 128
 
 # # Go performance profiling
 # pprof:

--- a/node/client.go
+++ b/node/client.go
@@ -78,7 +78,7 @@ func (p *clientProvider) GetRouteGroup(key string) (grp Group, ok bool) {
 }
 
 func (p *clientProvider) cacheLoad(key string) (Group, bool) {
-	v, expired, found := p.routeKeyCache.GetNoExp(key)
+	v, expired, found := p.routeKeyCache.GetWithoutExp(key)
 	if found && !expired { // cache hit
 		return v.(Group), true
 	}
@@ -86,7 +86,7 @@ func (p *clientProvider) cacheLoad(key string) (Group, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	v, expired, found = p.routeKeyCache.GetNoExp(key)
+	v, expired, found = p.routeKeyCache.GetWithoutExp(key)
 	if found && !expired { // double check
 		return v.(Group), true
 	}
@@ -109,7 +109,7 @@ func (p *clientProvider) populateCache(token string) (grp Group, ok bool) {
 
 		// for db error, we cache an empty group for the key by which no expiry cache value existed
 		// so that db pressure can be mitigrated by reducing too many subsequential queries.
-		if _, _, found := p.routeKeyCache.GetNoExp(token); !found {
+		if _, _, found := p.routeKeyCache.GetWithoutExp(token); !found {
 			p.routeKeyCache.Add(token, grp)
 		}
 

--- a/rpc/cache/cache_eth.go
+++ b/rpc/cache/cache_eth.go
@@ -38,7 +38,7 @@ func newEthCacheConfig() EthCacheConfig {
 	return cfg
 }
 
-func Init() {
+func MustInitFromViper() {
 	config := newEthCacheConfig()
 	viper.MustUnmarshalKey("requestControl.ethCache", &config)
 

--- a/rpc/cache/cache_eth.go
+++ b/rpc/cache/cache_eth.go
@@ -1,16 +1,49 @@
 package cache
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"time"
 
 	"github.com/Conflux-Chain/confura/node"
 	"github.com/Conflux-Chain/confura/util/rpc"
+	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/mcuadros/go-defaults"
 	"github.com/openweb3/web3go"
+	"github.com/openweb3/web3go/types"
+	"github.com/sirupsen/logrus"
 )
 
-var EthDefault = NewEth()
+var (
+	EthDefault *EthCache = newEthCache(newEthCacheConfig())
+)
+
+type EthCacheConfig struct {
+	NetVersionExpiration    time.Duration `default:"1m"`
+	ClientVersionExpiration time.Duration `default:"1m"`
+	ChainIdExpiration       time.Duration `default:"8760h"`
+	BlockNumberExpiration   time.Duration `default:"1s"`
+	PriceExpiration         time.Duration `default:"3s"`
+	CallCacheExpiration     time.Duration `default:"1s"`
+	CallCacheSize           int           `default:"128"`
+}
+
+// newEthCacheConfig returns a EthCacheConfig with default values.
+func newEthCacheConfig() EthCacheConfig {
+	var cfg EthCacheConfig
+	defaults.SetDefaults(&cfg)
+	return cfg
+}
+
+func Init() {
+	config := newEthCacheConfig()
+	viper.MustUnmarshalKey("requestControl.ethCache", &config)
+
+	EthDefault = newEthCache(config)
+}
 
 // EthCache memory cache for some evm space RPC methods
 type EthCache struct {
@@ -19,15 +52,17 @@ type EthCache struct {
 	chainIdCache       *expiryCache
 	priceCache         *expiryCache
 	blockNumberCache   *nodeExpiryCaches
+	callCache          *keyExpiryLruCaches
 }
 
-func NewEth() *EthCache {
+func newEthCache(cfg EthCacheConfig) *EthCache {
 	return &EthCache{
-		netVersionCache:    newExpiryCache(time.Minute),
-		clientVersionCache: newExpiryCache(time.Minute),
-		chainIdCache:       newExpiryCache(time.Hour * 24 * 365 * 100),
-		priceCache:         newExpiryCache(3 * time.Second),
-		blockNumberCache:   newNodeExpiryCaches(time.Second),
+		netVersionCache:    newExpiryCache(cfg.NetVersionExpiration),
+		clientVersionCache: newExpiryCache(cfg.ClientVersionExpiration),
+		chainIdCache:       newExpiryCache(cfg.ChainIdExpiration),
+		priceCache:         newExpiryCache(cfg.PriceExpiration),
+		blockNumberCache:   newNodeExpiryCaches(cfg.BlockNumberExpiration),
+		callCache:          newKeyExpiryLruCaches(cfg.CallCacheExpiration, cfg.CallCacheSize),
 	}
 }
 
@@ -91,4 +126,51 @@ func (cache *EthCache) GetBlockNumber(client *node.Web3goClient) (*hexutil.Big, 
 	}
 
 	return (*hexutil.Big)(val.(*big.Int)), nil
+}
+
+func (cache *EthCache) Call(client *node.Web3goClient, callRequest types.CallRequest, blockNum *types.BlockNumberOrHash) ([]byte, error) {
+	nodeName := rpc.Url2NodeName(client.URL)
+
+	cacheKey, err := generateCallCacheKey(nodeName, callRequest, blockNum)
+	if err != nil {
+		// This should rarely happen, but if it does, we don't want to fail the entire request due to cache error.
+		// The error is logged and the request is forwarded to the node directly.
+		logrus.WithFields(logrus.Fields{
+			"nodeName": nodeName,
+			"callReq":  callRequest,
+			"blockNum": blockNum,
+		}).WithError(err).Error("Failed to generate cache key for `eth_call`")
+		return client.Eth.Call(callRequest, blockNum)
+	}
+
+	val, err := cache.callCache.getOrUpdate(cacheKey, func() (interface{}, error) {
+		return client.Eth.Call(callRequest, blockNum)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return val.([]byte), nil
+}
+
+func generateCallCacheKey(nodeName string, callRequest types.CallRequest, blockNum *types.BlockNumberOrHash) (string, error) {
+	// Create a map of parameters to be serialized
+	params := map[string]interface{}{
+		"nodeName":    nodeName,
+		"callRequest": callRequest,
+		"blockNum":    blockNum,
+	}
+
+	// Serialize the parameters to JSON
+	jsonBytes, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
+
+	// Generate MD5 hash
+	hash := md5.New()
+	hash.Write(jsonBytes)
+
+	// Convert hash to a hexadecimal string
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -25,15 +25,15 @@ var (
 )
 
 func Init() {
-	var constraint struct {
+	var resrcLimit struct {
 		MaxGetLogsResponseBytes uint64 `default:"10485760"` // default 10MB
 	}
-	viper.MustUnmarshalKey("constraints.rpc", &constraint)
+	viper.MustUnmarshalKey("requestControl.resourceLimits", &resrcLimit)
 
-	maxGetLogsResponseBytes = constraint.MaxGetLogsResponseBytes
+	maxGetLogsResponseBytes = resrcLimit.MaxGetLogsResponseBytes
 	errResponseBodySizeTooLarge = fmt.Errorf(
 		"result body size is too large with more than %d bytes, please narrow down your filter condition",
-		constraint.MaxGetLogsResponseBytes,
+		resrcLimit.MaxGetLogsResponseBytes,
 	)
 }
 

--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -24,7 +24,7 @@ var (
 	errEventLogsTooStale = errors.New("event logs are too stale (already pruned)")
 )
 
-func Init() {
+func MustInitFromViper() {
 	var resrcLimit struct {
 		MaxGetLogsResponseBytes uint64 `default:"10485760"` // default 10MB
 	}

--- a/rpc/handler/eth_state.go
+++ b/rpc/handler/eth_state.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/Conflux-Chain/confura/node"
+	"github.com/Conflux-Chain/confura/rpc/cache"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/openweb3/web3go/types"
@@ -104,7 +105,7 @@ func (h *EthStateHandler) Call(
 	blockNum *types.BlockNumberOrHash,
 ) ([]byte, error) {
 	result, err, usefs := h.doRequest(ctx, w3c, func(w3c *node.Web3goClient) (interface{}, error) {
-		return w3c.Eth.Call(callRequest, blockNum)
+		return cache.EthDefault.Call(w3c, callRequest, blockNum)
 	})
 
 	metrics.Registry.RPC.Percentage("eth_call", "fullState").Mark(usefs)

--- a/rpc/server_middleware.go
+++ b/rpc/server_middleware.go
@@ -22,10 +22,10 @@ const (
 
 func MustInit() {
 	// init cache
-	cache.Init()
+	cache.MustInitFromViper()
 
 	// init handler
-	handler.Init()
+	handler.MustInitFromViper()
 
 	// init metrics
 	initMetrics()

--- a/rpc/server_middleware.go
+++ b/rpc/server_middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/Conflux-Chain/confura/node"
+	"github.com/Conflux-Chain/confura/rpc/cache"
 	"github.com/Conflux-Chain/confura/rpc/handler"
 	"github.com/Conflux-Chain/confura/util/rate"
 	"github.com/Conflux-Chain/confura/util/rpc/handlers"
@@ -20,6 +21,9 @@ const (
 )
 
 func MustInit() {
+	// init cache
+	cache.Init()
+
 	// init handler
 	handler.Init()
 

--- a/store/log_filter.go
+++ b/store/log_filter.go
@@ -53,7 +53,7 @@ func initLogFilter() {
 		MaxSplitBlockRange uint64 `default:"1000"`
 	}
 
-	viper.MustUnmarshalKey("constraints.logfilter", &lfc)
+	viper.MustUnmarshalKey("requestControl.logfilter", &lfc)
 
 	MaxLogBlockHashesSize = lfc.MaxBlockHashCount
 	MaxLogFilterAddrCount = lfc.MaxAddressCount

--- a/util/lru.go
+++ b/util/lru.go
@@ -13,6 +13,9 @@ type expirableValue struct {
 	expiresAt time.Time
 }
 
+// TimeNowFunc returns current time
+type TimeNowFunc func() time.Time
+
 // ExpirableLruCache naive implementation of LRU cache with fixed TTL expiration duration.
 // This cache uses a lazy eviction policy, by which the expired entry will be purged when
 // it's being looked up.
@@ -20,11 +23,18 @@ type ExpirableLruCache struct {
 	lru *lru.Cache
 	mu  sync.Mutex
 	ttl time.Duration
+
+	// custom `time.Now` function, which could be used for testing
+	timeNowFunc func() time.Time
 }
 
-func NewExpirableLruCache(size int, ttl time.Duration) *ExpirableLruCache {
-	cache, _ := lru.New(size)
-	return &ExpirableLruCache{lru: cache, ttl: ttl}
+func NewExpirableLruCache(size int, ttl time.Duration, timeNowFunc ...func() time.Time) *ExpirableLruCache {
+	nowFunc := time.Now
+	if len(timeNowFunc) > 0 {
+		nowFunc = timeNowFunc[0]
+	}
+	cache, _ := lru.New(max(size, 1))
+	return &ExpirableLruCache{lru: cache, ttl: ttl, timeNowFunc: nowFunc}
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
@@ -32,12 +42,7 @@ func (c *ExpirableLruCache) Add(key, value interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	ev := &expirableValue{
-		value:     value,
-		expiresAt: time.Now().Add(c.ttl),
-	}
-
-	return c.lru.Add(key, ev)
+	return c.add(key, value)
 }
 
 // Get looks up a key's value from the cache. Will purge the entry and return nil
@@ -46,25 +51,54 @@ func (c *ExpirableLruCache) Get(key interface{}) (v interface{}, found bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	cv, ok := c.lru.Get(key) // not found
-	if !ok {
+	v, expired, found := c.get(key)
+	if !found { // not found
 		return nil, false
 	}
 
-	ev := cv.(*expirableValue)
-	if ev.expiresAt.Before(time.Now()) { // expired
+	if expired { // expired
 		c.lru.Remove(key)
-		return ev.value, false
+		return nil, false
 	}
 
-	return ev.value, true
+	return v, true
 }
 
-// GetNoExp looks up a key's value from the cache without expiration action.
-func (c *ExpirableLruCache) GetNoExp(key interface{}) (v interface{}, expired, found bool) {
+// GetOrUpdate gets or updates the value for the given cache key.
+// If the entry existed but expired, it will be purged and the updateFunc will be called.
+// If the updateFunc returns an error, the function will return that error.
+// If the entry existed and not expired, the function will return the existing value.
+func (c *ExpirableLruCache) GetOrUpdate(key interface{}, updateFunc func() (interface{}, error)) (interface{}, error) {
+	v, expired, found := c.get(key)
+	if found && !expired {
+		return v, nil
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// double check for concurrency
+	v, expired, found = c.get(key)
+	if found && !expired {
+		return v, nil
+	}
+
+	// update cache
+	v, err := updateFunc()
+	if err != nil {
+		return nil, err
+	}
+	c.add(key, v)
+
+	return v, nil
+}
+
+// GetWithoutExp looks up a key's value from the cache without expiration action.
+func (c *ExpirableLruCache) GetWithoutExp(key interface{}) (v interface{}, expired, found bool) {
+	return c.get(key)
+}
+
+func (c *ExpirableLruCache) get(key interface{}) (v interface{}, expired, found bool) {
 	cv, ok := c.lru.Get(key) // not found
 	if !ok {
 		return nil, false, false
@@ -72,9 +106,18 @@ func (c *ExpirableLruCache) GetNoExp(key interface{}) (v interface{}, expired, f
 
 	ev := cv.(*expirableValue)
 
-	if ev.expiresAt.Before(time.Now()) { // expired
+	if ev.expiresAt.Before(c.timeNowFunc()) { // expired
 		return ev.value, true, true
 	}
 
 	return ev.value, false, true
+}
+
+func (c *ExpirableLruCache) add(key, value interface{}) bool {
+	ev := &expirableValue{
+		value:     value,
+		expiresAt: c.timeNowFunc().Add(c.ttl),
+	}
+
+	return c.lru.Add(key, ev)
 }

--- a/util/lru_test.go
+++ b/util/lru_test.go
@@ -1,0 +1,158 @@
+package util_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Conflux-Chain/confura/util"
+	"github.com/pkg/errors"
+)
+
+// mockTime is used to simulate time progression in tests.
+type mockTime struct {
+	mu          sync.Mutex
+	currentTime time.Time
+}
+
+func (m *mockTime) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentTime
+}
+
+func (m *mockTime) Add(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentTime = m.currentTime.Add(d)
+}
+
+// TestAddAndGet tests the basic Add and Get functionality.
+func TestAddAndGet(t *testing.T) {
+	cache := util.NewExpirableLruCache(5, 50*time.Millisecond)
+	cache.Add("key1", "value1")
+
+	value, found := cache.Get("key1")
+	if !found || value != "value1" {
+		t.Errorf("Expected to find key1 with value 'value1', got '%v', found: %v", value, found)
+	}
+}
+
+// TestExpiration tests that entries expire after the TTL.
+func TestExpiration(t *testing.T) {
+	mt := &mockTime{currentTime: time.Now()}
+	cache := util.NewExpirableLruCache(5, 50*time.Millisecond, mt.Now)
+	cache.Add("key1", "value1")
+
+	// Simulate time passing beyond the TTL
+	mt.Add(60 * time.Millisecond)
+
+	value, found := cache.Get("key1")
+	if found || value != nil {
+		t.Errorf("Expected key1 to be expired and not found, got '%v', found: %v", value, found)
+	}
+}
+
+// TestGetOrUpdate tests the GetOrUpdate method.
+func TestGetOrUpdate(t *testing.T) {
+	mt := &mockTime{currentTime: time.Now()}
+	cache := util.NewExpirableLruCache(5, 50*time.Millisecond, mt.Now)
+
+	updateFunc := func() (interface{}, error) {
+		return "value1", nil
+	}
+
+	// Initially, the key does not exist, so updateFunc should be called
+	value, err := cache.GetOrUpdate("key1", updateFunc)
+	if err != nil || value != "value1" {
+		t.Errorf("Expected to get 'value1', got '%v', error: %v", value, err)
+	}
+
+	// Fetch again; since it's not expired, should return cached value
+	value, err = cache.GetOrUpdate("key1", func() (interface{}, error) {
+		return "value2", nil
+	})
+	if err != nil || value != "value1" {
+		t.Errorf("Expected to get 'value1' from cache, got '%v', error: %v", value, err)
+	}
+
+	// Advance time to expire the entry
+	mt.Add(60 * time.Millisecond)
+
+	// Now, updateFunc should be called again
+	value, err = cache.GetOrUpdate("key1", func() (interface{}, error) {
+		return "value3", nil
+	})
+	if err != nil || value != "value3" {
+		t.Errorf("Expected to get 'value3' after expiration, got '%v', error: %v", value, err)
+	}
+}
+
+// TestGetWithoutExp tests the GetWithoutExp method.
+func TestGetWithoutExp(t *testing.T) {
+	mt := &mockTime{currentTime: time.Now()}
+	cache := util.NewExpirableLruCache(5, 50*time.Millisecond, mt.Now)
+	cache.Add("key1", "value1")
+
+	value, expired, found := cache.GetWithoutExp("key1")
+	if !found || expired {
+		t.Errorf("Expected to find key1 not expired, found: %v, expired: %v", found, expired)
+	}
+	if value != "value1" {
+		t.Errorf("Expected value 'value1', got '%v'", value)
+	}
+
+	// Advance time to expire the entry
+	mt.Add(60 * time.Millisecond)
+
+	value, expired, found = cache.GetWithoutExp("key1")
+	if !found || !expired {
+		t.Errorf("Expected to find key1 expired, found: %v, expired: %v", found, expired)
+	}
+	if value != "value1" {
+		t.Errorf("Expected value 'value1', got '%v'", value)
+	}
+}
+
+// TestLRUEviction tests the LRU eviction policy of the cache.
+func TestLRUEviction(t *testing.T) {
+	mt := &mockTime{currentTime: time.Now()}
+	cache := util.NewExpirableLruCache(3, time.Minute, mt.Now)
+	cache.Add("key1", "value1")
+	cache.Add("key2", "value2")
+	cache.Add("key3", "value3")
+
+	// Access key1 and key2 to make key3 the least recently used
+	cache.Get("key1")
+	cache.Get("key2")
+
+	// Add a new key to trigger eviction
+	cache.Add("key4", "value4")
+
+	// key3 should have been evicted
+	_, found := cache.Get("key3")
+	if found {
+		t.Errorf("Expected key3 to be evicted, but it was found")
+	}
+
+	// key1, key2, key4 should still be present
+	for _, k := range []string{"key1", "key2", "key4"} {
+		if _, found := cache.Get(k); !found {
+			t.Errorf("Expected %s to be present, but it was not found", k)
+		}
+	}
+}
+
+// TestUpdateFuncError tests the behavior when updateFunc returns an error.
+func TestUpdateFuncError(t *testing.T) {
+	mt := &mockTime{currentTime: time.Now()}
+	cache := util.NewExpirableLruCache(5, 50*time.Millisecond, mt.Now)
+	updateFunc := func() (interface{}, error) {
+		return nil, errors.New("update failed")
+	}
+
+	value, err := cache.GetOrUpdate("key1", updateFunc)
+	if err == nil || value != nil {
+		t.Errorf("Expected error 'update failed', got value '%v', error: %v", value, err)
+	}
+}

--- a/util/rate/loader.go
+++ b/util/rate/loader.go
@@ -64,7 +64,7 @@ func (l *KeyLoader) Load(key string) (*KeyInfo, bool) {
 }
 
 func (l *KeyLoader) cacheLoad(key string) (*KeyInfo, bool) {
-	cv, expired, found := l.keyCache.GetNoExp(key)
+	cv, expired, found := l.keyCache.GetWithoutExp(key)
 	if found && !expired { // found in cache
 		return cv.(*KeyInfo), true
 	}
@@ -72,7 +72,7 @@ func (l *KeyLoader) cacheLoad(key string) (*KeyInfo, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	cv, expired, found = l.keyCache.GetNoExp(key)
+	cv, expired, found = l.keyCache.GetWithoutExp(key)
 	if found && !expired { // double check
 		return cv.(*KeyInfo), true
 	}
@@ -94,7 +94,7 @@ func (l *KeyLoader) populateCache(key string) (*KeyInfo, bool) {
 
 		// for db error, we cache nil for the key by which no expiry cache value existed
 		// so that db pressure can be mitigrated by reducing too many subsequential queries.
-		if _, _, found := l.keyCache.GetNoExp(key); !found {
+		if _, _, found := l.keyCache.GetWithoutExp(key); !found {
 			l.keyCache.Add(key, (*KeyInfo)(nil))
 		}
 


### PR DESCRIPTION
- Introduce an expirable LRU cache to handle EVM call results
- Adding unit testing for the expirable LRU cache with mock fake time support
- Allow cache parameters (expiration times, sizes) to be set via configuration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/223)
<!-- Reviewable:end -->
