### PR TITLE
Implement multiple methods for retrieving ETH txn receipts

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -17,14 +17,11 @@ rpc:
     ethNode: http://evmtestnet.confluxrpc.com
     # core space fullnode endpoint (optional)
     # cfxNode: http://test.confluxrpc.com
-    # Implementation method for batch receipts, available options are:
-    # 0 - `parity_getBlockReceipts`
-    # 1 - `eth_getTransactionReceipt`
-    # 2 - `eth_getBlockReceipts`
-    # batchRcptImpl: 0
-    # The number of concurrencies to retrieve batch receipts for better performance, only effective
-    # when `eth_getTransactionReceipt` is used as the implementation method.
-    # batchRcptConcurrency: 4
+    # Available transaction receipt retrieval methods are:
+    # 0 - `parity_getBlockReceipts`, 1 - `eth_getTransactionReceipt`, 2 - `eth_getBlockReceipts`
+    # rcptRetrievalMethod: 0
+    # Number of concurrent retrieval operations, effective only for `eth_getTransactionReceipt`
+    # rcptRetrievalConcurrency: 4
     # Available exposed modules are `cfx`, `txpool`, `trace`, if empty all APIs will be exposed.
     # exposedModules: []
     # Served HTTP endpoint
@@ -137,8 +134,11 @@ sync:
 
   # # EVM space sync configurations
   # eth:
-  #   # Whether to use `parity_getBlockReceipts` to batch get receipts
-  #   useBatch: false
+  #   # Available transaction receipt retrieval methods are:
+  #   # 0 - `parity_getBlockReceipts`, 1 - `eth_getTransactionReceipt`, 2 - `eth_getBlockReceipts`
+  #   rcptRetrievalMethod: 0
+  #   # Number of concurrent retrieval operations, effective only for `eth_getTransactionReceipt`
+  #   rcptRetrievalConcurrency: 4
   #   # The block number from which to sync evm space, better use the evm space hardfork point:
   #   # for mainnet it is 36935000, for testnet it is 61465000
   #   fromBlock: 61465000

--- a/config/config.yml
+++ b/config/config.yml
@@ -17,11 +17,6 @@ rpc:
     ethNode: http://evmtestnet.confluxrpc.com
     # core space fullnode endpoint (optional)
     # cfxNode: http://test.confluxrpc.com
-    # Available transaction receipt retrieval methods are:
-    # 0 - `parity_getBlockReceipts`, 1 - `eth_getTransactionReceipt`, 2 - `eth_getBlockReceipts`
-    # rcptRetrievalMethod: 0
-    # Number of concurrent retrieval operations, effective only for `eth_getTransactionReceipt`
-    # rcptRetrievalConcurrency: 4
     # Available exposed modules are `cfx`, `txpool`, `trace`, if empty all APIs will be exposed.
     # exposedModules: []
     # Served HTTP endpoint
@@ -445,6 +440,16 @@ node:
 #     # LRU Cache size and expiration time duration for 'eth_call'
 #     callCacheExpiration: 1s
 #     callCacheSize: 128
+#
+#   # ETH receipt retrieval configuration
+#   ethReceiptRetrieval:
+#     # 0 - Auto-detect (tries following methods in order)
+#     # 1 - `eth_getBlockReceipts` (limited support)
+#     # 2 - `parity_getBlockReceipts` (limited support)
+#     # 3 - `eth_getTransactionReceipt` (universal but slower)
+#     method: 0
+#     # Concurrent operations for `eth_getTransactionReceipt` only
+#     concurrency: 0
 
 # # Go performance profiling
 # pprof:

--- a/config/config.yml
+++ b/config/config.yml
@@ -129,11 +129,6 @@ sync:
 
   # # EVM space sync configurations
   # eth:
-  #   # Available transaction receipt retrieval methods are:
-  #   # 0 - `parity_getBlockReceipts`, 1 - `eth_getTransactionReceipt`, 2 - `eth_getBlockReceipts`
-  #   rcptRetrievalMethod: 0
-  #   # Number of concurrent retrieval operations, effective only for `eth_getTransactionReceipt`
-  #   rcptRetrievalConcurrency: 4
   #   # The block number from which to sync evm space, better use the evm space hardfork point:
   #   # for mainnet it is 36935000, for testnet it is 61465000
   #   fromBlock: 61465000

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -176,8 +176,10 @@ func nativeSpaceBridgeApis(config *CfxBridgeServerConfig) ([]API, error) {
 		{
 			Namespace: "cfx",
 			Version:   "1.0",
-			Service:   cfxbridge.NewCfxAPI(eth, uint32(*ethChainId), cfx, config.BatchRcptImpl, config.BatchRcptConcurrency),
-			Public:    true,
+			Service: cfxbridge.NewCfxAPI(
+				eth, uint32(*ethChainId), cfx, config.RcptRetrievalMethod, config.RcptRetrievalConcurrency,
+			),
+			Public: true,
 		}, {
 			Namespace: "trace",
 			Version:   "1.0",

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -176,10 +176,8 @@ func nativeSpaceBridgeApis(config *CfxBridgeServerConfig) ([]API, error) {
 		{
 			Namespace: "cfx",
 			Version:   "1.0",
-			Service: cfxbridge.NewCfxAPI(
-				eth, uint32(*ethChainId), cfx, config.RcptRetrievalMethod, config.RcptRetrievalConcurrency,
-			),
-			Public: true,
+			Service:   cfxbridge.NewCfxAPI(eth, uint32(*ethChainId), cfx),
+			Public:    true,
 		}, {
 			Namespace: "trace",
 			Version:   "1.0",

--- a/rpc/cfxbridge/cfx_api.go
+++ b/rpc/cfxbridge/cfx_api.go
@@ -15,22 +15,16 @@ import (
 )
 
 type CfxAPI struct {
-	w3c           *web3go.Client
-	cfx           *sdk.Client // optional
-	ethNetworkId  uint32
-	receiptOption store.EthReceiptRetrievalOption
+	w3c          *web3go.Client
+	cfx          *sdk.Client // optional
+	ethNetworkId uint32
 }
 
-func NewCfxAPI(
-	w3client *web3go.Client, ethNetId uint32, cfxClient *sdk.Client, rcptMethod int, rcptConcurrency int) *CfxAPI {
+func NewCfxAPI(w3client *web3go.Client, ethNetId uint32, cfxClient *sdk.Client) *CfxAPI {
 	return &CfxAPI{
 		w3c:          w3client,
 		cfx:          cfxClient,
 		ethNetworkId: ethNetId,
-		receiptOption: store.EthReceiptRetrievalOption{
-			Method:      store.EthReceiptRetrievalMethod(rcptMethod),
-			Concurrency: rcptConcurrency,
-		},
 	}
 }
 
@@ -263,7 +257,7 @@ func (api *CfxAPI) GetTransactionReceipt(ctx context.Context, txHash common.Hash
 }
 
 func (api *CfxAPI) GetEpochReceipts(ctx context.Context, bnh EthBlockNumberOrHash) ([][]*types.TransactionReceipt, error) {
-	receipts, err := store.QueryEthReceipt(ctx, api.w3c, *bnh.ToArg(), api.receiptOption)
+	receipts, err := store.QueryEthReceipt(ctx, api.w3c, *bnh.ToArg())
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -72,12 +72,10 @@ func MustNewEvmSpaceServer(
 }
 
 type CfxBridgeServerConfig struct {
-	EthNode                  string
-	CfxNode                  string
-	RcptRetrievalMethod      int
-	RcptRetrievalConcurrency int `default:"4"`
-	ExposedModules           []string
-	Endpoint                 string `default:":32537"`
+	EthNode        string
+	CfxNode        string
+	ExposedModules []string
+	Endpoint       string `default:":32537"`
 }
 
 func MustNewNativeSpaceBridgeServer(registry *rate.Registry, config *CfxBridgeServerConfig) *rpc.Server {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -72,12 +72,12 @@ func MustNewEvmSpaceServer(
 }
 
 type CfxBridgeServerConfig struct {
-	EthNode              string
-	CfxNode              string
-	BatchRcptImpl        int
-	BatchRcptConcurrency int `default:"4"`
-	ExposedModules       []string
-	Endpoint             string `default:":32537"`
+	EthNode                  string
+	CfxNode                  string
+	RcptRetrievalMethod      int
+	RcptRetrievalConcurrency int `default:"4"`
+	ExposedModules           []string
+	Endpoint                 string `default:":32537"`
 }
 
 func MustNewNativeSpaceBridgeServer(registry *rate.Registry, config *CfxBridgeServerConfig) *rpc.Server {

--- a/store/eth_data.go
+++ b/store/eth_data.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Conflux-Chain/confura/util/metrics"
@@ -9,6 +10,19 @@ import (
 	"github.com/openweb3/web3go/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	ErrReceiptRetrievalMethodNotSupported = errors.New("receipt retrieval method not supported")
+)
+
+type EthReceiptRetrievalMethod int
+
+const (
+	EthReceiptRetrievalMethodParityBlockReceipts = iota
+	EthReceiptRetrievalMethodEthTxnReceipt
+	EthReceiptRetrievalMethodEthBlockReceipts
 )
 
 // EthData wraps the evm space blockchain data.
@@ -37,19 +51,68 @@ func (current *EthData) IsContinuousTo(prev *EthData) (continuous bool, desc str
 	return true, ""
 }
 
+func GetBlockByBlockNumberOrHash(
+	ctx context.Context,
+	w3c *web3go.Client,
+	bnh types.BlockNumberOrHash,
+	isFull bool,
+) (*types.Block, error) {
+	if bn, ok := bnh.Number(); ok {
+		return w3c.WithContext(ctx).Eth.BlockByNumber(bn, isFull)
+	}
+
+	return w3c.WithContext(ctx).Eth.BlockByHash(*bnh.BlockHash, isFull)
+}
+
+type EthReceiptRetrievalOption struct {
+	Method      EthReceiptRetrievalMethod
+	Concurrency int
+
+	// pre-fetched data can be used to accelerate the query eg., block header etc.
+	Prefetched interface{}
+}
+
+func QueryEthReceipt(
+	ctx context.Context,
+	w3c *web3go.Client,
+	bnh types.BlockNumberOrHash,
+	opt EthReceiptRetrievalOption,
+) ([]*types.Receipt, error) {
+	switch opt.Method {
+	case EthReceiptRetrievalMethodParityBlockReceipts:
+		return queryEthReceiptByParityBlockReceipts(ctx, w3c, bnh)
+	case EthReceiptRetrievalMethodEthTxnReceipt:
+		return queryEthReceiptByEthTxnReceipt(ctx, w3c, bnh, opt)
+	case EthReceiptRetrievalMethodEthBlockReceipts:
+		return queryEthReceiptByEthBlockReceipts(ctx, w3c, bnh)
+	default:
+		return nil, ErrReceiptRetrievalMethodNotSupported
+	}
+}
+
 // QueryEthData queries blockchain data for the specified block number.
-func QueryEthData(w3c *web3go.Client, blockNumber uint64, useBatch bool) (*EthData, error) {
+func QueryEthData(
+	ctx context.Context,
+	w3c *web3go.Client,
+	blockNumber uint64,
+	rcptOpt EthReceiptRetrievalOption,
+) (*EthData, error) {
 	updater := metrics.Registry.Sync.QueryEpochData("eth")
 	defer updater.Update()
 
-	data, err := queryEthData(w3c, blockNumber, useBatch)
+	data, err := queryEthData(ctx, w3c, blockNumber, rcptOpt)
 	metrics.Registry.Sync.QueryEpochDataAvailability("eth").
 		Mark(err == nil || errors.Is(err, ErrChainReorged))
 
 	return data, err
 }
 
-func queryEthData(w3c *web3go.Client, blockNumber uint64, useBatch bool) (*EthData, error) {
+func queryEthData(
+	ctx context.Context,
+	w3c *web3go.Client,
+	blockNumber uint64,
+	rcptOpt EthReceiptRetrievalOption,
+) (*EthData, error) {
 	// Get block by number
 	block, err := w3c.Eth.BlockByNumber(types.BlockNumber(blockNumber), true)
 
@@ -61,77 +124,187 @@ func queryEthData(w3c *web3go.Client, blockNumber uint64, useBatch bool) (*EthDa
 		return nil, errors.WithMessagef(err, "failed to get block by number %v", blockNumber)
 	}
 
-	logger := logrus.WithFields(logrus.Fields{
-		"blockHash": block.Hash, "blockNumber": blockNumber,
-	})
+	// Set the block as prefetched data so that no need to query it again.
+	rcptOpt.Prefetched = block
 
-	var blockReceipts []types.Receipt
-	if useBatch {
-		// Batch get block receipts.
-		blockNumOrHash := types.BlockNumberOrHashWithNumber(types.BlockNumber(blockNumber))
-		blockReceipts, err = w3c.Parity.BlockReceipts(&blockNumOrHash)
-		if err != nil {
-			logger.WithError(err).Info("Failed to batch query ETH block receipts")
-			return nil, errors.WithMessage(err, "failed to get block receipts")
-		}
+	blockNumOrHash := types.BlockNumberOrHashWithNumber(types.BlockNumber(blockNumber))
+	blockReceipts, err := QueryEthReceipt(ctx, w3c, blockNumOrHash, rcptOpt)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get block receipts")
+	}
+
+	if blockReceipts == nil {
+		return nil, errors.WithMessage(ErrChainReorged, "block receipts nil")
 	}
 
 	txReceipts := map[common.Hash]*types.Receipt{}
 	blockTxs := block.Transactions.Transactions()
 
 	for i := 0; i < len(blockTxs); i++ {
-		txHash := blockTxs[i].Hash
-		blogger := logger.WithFields(logrus.Fields{"txHash": txHash, "i": i})
-
-		var receipt *types.Receipt
-		if useBatch {
-			if blockReceipts == nil {
-				blogger.Info("Failed to match tx receipts due to block receipts nil (regarded as chain reorg)")
-				return nil, errors.WithMessage(ErrChainReorged, "batch retrieved block receipts nil")
-			}
-
-			if i >= len(blockReceipts) {
-				blogger.WithField("blockReceipts", blockReceipts).Info(
-					"Failed to match tx receipts due to block receipts out of bound",
-				)
-				return nil, errors.New("batch retrieved block receipts out of bound")
-			}
-
-			receipt = &blockReceipts[i]
-		} else {
-			receipt, err = w3c.Eth.TransactionReceipt(txHash)
-			if err != nil {
-				blogger.WithError(err).Info("Failed to query ETH transaction receipt")
-				return nil, errors.WithMessagef(err, "failed to get receipt for tx %v", txHash)
-			}
+		receipt := blockReceipts[i]
+		if err := validateEthTxnReceipt(block, i, receipt); err != nil {
+			return nil, errors.WithMessage(err, "failed to validate txn receipt")
 		}
 
-		// sanity check in case of chain re-org
-		switch {
-		case receipt == nil: // receipt shouldn't be nil unless chain re-org
-			err = errors.WithMessage(ErrChainReorged, "tx receipt nil")
-		case receipt.BlockHash != block.Hash:
-			blogger = blogger.WithFields(logrus.Fields{
-				"rcptBlockHash": receipt.BlockHash, "expectedBlockHash": block.Hash,
-			})
-			err = errors.WithMessage(ErrChainReorged, "receipt block hash mismatch")
-		case receipt.BlockNumber != blockNumber:
-			blogger = blogger.WithFields(logrus.Fields{
-				"rcptBlockNumber": receipt.BlockNumber, "expectedBlockNumber": blockNumber,
-			})
-			err = errors.WithMessage(ErrChainReorged, "receipt block number mismatch")
-		case receipt.TransactionHash != txHash:
-			blogger = blogger.WithField("rcptTxHash", receipt.TransactionHash)
-			err = errors.WithMessage(ErrChainReorged, "receipt tx hash mismatch")
-		}
-
-		if err != nil {
-			blogger.WithError(err).Info("Failed to query ETH transaction receipt (regarded as chain re-org)")
-			return nil, err
-		}
-
-		txReceipts[txHash] = receipt
+		txReceipts[blockTxs[i].Hash] = receipt
 	}
 
 	return &EthData{blockNumber, block, txReceipts}, nil
+}
+
+func queryEthReceiptByParityBlockReceipts(
+	ctx context.Context,
+	w3c *web3go.Client,
+	bnh types.BlockNumberOrHash,
+) (receipts []*types.Receipt, err error) {
+	blockReceipts, err := w3c.WithContext(ctx).Parity.BlockReceipts(&bnh)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get parity block receipts")
+	}
+
+	for i := range blockReceipts {
+		receipts = append(receipts, &blockReceipts[i])
+	}
+
+	return receipts, nil
+}
+
+func newEthTxnRetrievalError(cause error, txnHash common.Hash) error {
+	return errors.WithMessagef(cause, "failed to query receipt for txn %v", txnHash)
+}
+
+func validateEthTxnReceipt(block *types.Block, txnIndex int, receipt *types.Receipt) error {
+	// sanity check in case of chain re-org
+	switch {
+	case receipt == nil: // receipt shouldn't be nil unless chain re-org
+		return errors.WithMessagef(
+			ErrChainReorged, "nil txn receipt for block %v at index %v", block.Hash, txnIndex,
+		)
+	case receipt.BlockHash != block.Hash:
+		return errors.WithMessagef(
+			ErrChainReorged, "receipt block hash %v mismatch for block %v at index %v",
+			receipt.BlockHash, block.Hash, txnIndex,
+		)
+	case receipt.BlockNumber != block.Number.Uint64():
+		return errors.WithMessagef(
+			ErrChainReorged, "receipt block number #%v mismatch for block #%v at index %v",
+			receipt.BlockNumber, block.Nonce.Uint64(), txnIndex,
+		)
+	default:
+		txnHashes := getBlockTxnHashes(block)
+		if len(txnHashes) <= txnIndex {
+			return errors.Errorf(
+				"failed to match txn %v within block %v due to index %v out of bound",
+				receipt.TransactionHash, block.Hash, txnIndex,
+			)
+		}
+		if th := txnHashes[txnIndex]; th != receipt.TransactionHash {
+			return errors.WithMessagef(
+				ErrChainReorged, "receipt tx hash %v mismatch for txn %v within block %v at index %v",
+				receipt.TransactionHash, th, block.Hash, txnIndex,
+			)
+		}
+		return nil
+	}
+}
+
+func getBlockTxnHashes(block *types.Block) (txnHashes []common.Hash) {
+	if block.Transactions.Type() == types.TXLIST_HASH {
+		return block.Transactions.Hashes()
+	}
+
+	txns := block.Transactions.Transactions()
+	for i := 0; i < len(txns); i++ {
+		txnHashes = append(txnHashes, txns[i].Hash)
+	}
+	return txnHashes
+}
+
+func queryEthReceiptByEthTxnReceipt(
+	ctx context.Context,
+	w3c *web3go.Client,
+	bnh types.BlockNumberOrHash,
+	rcptOpt EthReceiptRetrievalOption,
+) (receipts []*types.Receipt, err error) {
+	block, ok := rcptOpt.Prefetched.(*types.Block)
+	if !ok || block == nil {
+		block, err = GetBlockByBlockNumberOrHash(ctx, w3c, bnh, false)
+		if err != nil {
+			return nil, errors.WithMessage(err, "failed to get block by block number or hash")
+		}
+	}
+	txnHashes := getBlockTxnHashes(block)
+
+	if rcptOpt.Concurrency == 0 {
+		for i := 0; i < len(txnHashes); i++ {
+			receipt, err := w3c.Eth.TransactionReceipt(txnHashes[i])
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"blockHash":   block.Hash,
+					"blockNumber": block.Number.Int64(),
+					"txnHash":     txnHashes[i],
+					"txnIndex":    i,
+				}).WithError(err).Info("Failed to query eth transaction receipt")
+				return nil, newEthTxnRetrievalError(err, txnHashes[i])
+			}
+
+			if err := validateEthTxnReceipt(block, i, receipt); err != nil {
+				return nil, errors.WithMessage(err, "failed to validate transaction receipt")
+			}
+			receipts = append(receipts, receipt)
+		}
+
+		return receipts, nil
+	}
+
+	errGrp, ctx := errgroup.WithContext(ctx)
+	errGrp.SetLimit(rcptOpt.Concurrency)
+
+	breakLoop, receipts := false, make([]*types.Receipt, len(txnHashes))
+	for idx := 0; !breakLoop && idx < len(txnHashes); idx++ {
+		// Capture loop variables
+		txnHash, rcptIdx := txnHashes[idx], idx
+
+		// Start goroutine for each transaction
+		errGrp.Go(func() error {
+			receipt, err := w3c.WithContext(ctx).Eth.TransactionReceipt(txnHash)
+			if err != nil {
+				return newEthTxnRetrievalError(err, txnHash)
+			}
+
+			if err := validateEthTxnReceipt(block, rcptIdx, receipt); err != nil {
+				return errors.WithMessage(err, "failed to validate transaction receipt")
+			}
+
+			// Thread safe to write here since receipt index is unique for each goroutine within the group.
+			receipts[rcptIdx] = receipt
+			return nil
+		})
+
+		select {
+		case <-ctx.Done():
+			// Break the loop if any error happened
+			breakLoop = true
+		default:
+		}
+	}
+
+	if err := errGrp.Wait(); err != nil {
+		return nil, err
+	}
+
+	return receipts, nil
+}
+
+func queryEthReceiptByEthBlockReceipts(
+	ctx context.Context,
+	w3c *web3go.Client,
+	bnh types.BlockNumberOrHash,
+) ([]*types.Receipt, error) {
+	blockReceipts, err := w3c.WithContext(ctx).Eth.BlockReceipts(&bnh)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get eth block receipts")
+	}
+
+	return blockReceipts, nil
 }

--- a/store/eth_data.go
+++ b/store/eth_data.go
@@ -3,9 +3,13 @@ package store
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/Conflux-Chain/confura/util/metrics"
+	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/go-rpc-provider/utils"
 	"github.com/openweb3/web3go"
 	"github.com/openweb3/web3go/types"
 	"github.com/pkg/errors"
@@ -13,17 +17,144 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	ErrReceiptRetrievalMethodNotSupported = errors.New("receipt retrieval method not supported")
-)
-
-type EthReceiptRetrievalMethod int
+type EthReceiptMethod uint32
 
 const (
-	EthReceiptRetrievalMethodParityBlockReceipts = iota
-	EthReceiptRetrievalMethodEthTxnReceipt
-	EthReceiptRetrievalMethodEthBlockReceipts
+	EthReceiptMethodAutoDetect = iota
+	EthReceiptMethodEthBlockReceipts
+	EthReceiptMethodParityBlockReceipts
+	EthReceiptMethodEthTxnReceipt
+	EthReceiptMethodEnd
 )
+
+// String returns the string representation of the EthReceiptMethod
+func (m EthReceiptMethod) String() string {
+	switch m {
+	case EthReceiptMethodAutoDetect:
+		return "auto detect"
+	case EthReceiptMethodEthBlockReceipts:
+		return "eth_blockReceipts"
+	case EthReceiptMethodParityBlockReceipts:
+		return "parity_blockReceipts"
+	case EthReceiptMethodEthTxnReceipt:
+		return "eth_getTransactionReceipt"
+	default:
+		return fmt.Sprintf("unknown receipt method (%d)", m)
+	}
+}
+
+// IsConcrete returns true if the method is a concrete receipt retrieval method (excluding auto-detect).
+func (m EthReceiptMethod) IsConcrete() bool {
+	return m > EthReceiptMethodAutoDetect && m < EthReceiptMethodEnd
+}
+
+type receiptRetriever func(context.Context, *web3go.Client, types.BlockNumberOrHash, EthReceiptOption) ([]*types.Receipt, error)
+
+var (
+	DefaultReceiptOption      EthReceiptOption
+	defaultRcptMethodDetector EthReceiptMethodDetector
+
+	// Prioritized methods in order to detect the best receipt retrieval method
+	receiptRetrievalMethods = []struct {
+		method EthReceiptMethod
+		query  receiptRetriever
+	}{
+		{EthReceiptMethodEthBlockReceipts, queryEthReceiptByEthBlockReceipts},
+		{EthReceiptMethodParityBlockReceipts, queryEthReceiptByParityBlockReceipts},
+		{EthReceiptMethodEthTxnReceipt, queryEthReceiptByEthTxnReceipt},
+	}
+)
+
+func initEth() {
+	// Initialize DefaultEthOption with config values from viper
+	viper.MustUnmarshalKey(
+		"requestControl.ethReceiptRetrieval", &DefaultReceiptOption,
+	)
+}
+
+type EthReceiptOption struct {
+	Method      EthReceiptMethod
+	Concurrency int
+
+	// Pre-fetched data can be used to accelerate the query eg., block header etc.
+	Prefetched interface{}
+}
+
+// EthReceiptMethodDetector detects the best method for retrieving Ethereum receipts.
+// The detection occurs only once to optimize performance by caching the result.
+type EthReceiptMethodDetector struct {
+	mu     sync.Mutex
+	method EthReceiptMethod // Cached method
+}
+
+// Detect determines the best receipt retrieval method.
+// If a method has already been detected, it returns the cached method.
+// Otherwise, it attempts to detect the best method.
+func (d *EthReceiptMethodDetector) Detect(
+	ctx context.Context,
+	client *web3go.Client,
+	bnh types.BlockNumberOrHash,
+) (EthReceiptMethod, error) {
+	// Check if method was already detected
+	if method := d.load(); method.IsConcrete() {
+		return method, nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Double-check
+	if method := d.load(); method.IsConcrete() {
+		return method, nil
+	}
+
+	// Perform best method detection
+	method, err := d.detect(ctx, client, bnh)
+	if err != nil {
+		return 0, wrapDetectionError(err)
+	}
+
+	// Cache the detected method for future calls
+	d.store(method)
+
+	logrus.WithField("method", method).Debug("Best receipt retrieval method detected")
+	return method, nil
+}
+
+// load returns the cached method.
+func (d *EthReceiptMethodDetector) load() EthReceiptMethod {
+	method := atomic.LoadUint32((*uint32)(&d.method))
+	return EthReceiptMethod(method)
+}
+
+// store caches the detected method.
+func (d *EthReceiptMethodDetector) store(method EthReceiptMethod) {
+	atomic.StoreUint32((*uint32)(&d.method), uint32(method))
+}
+
+// detect attempts to detect the best receipt retrieval method by trying several options.
+func (d *EthReceiptMethodDetector) detect(
+	ctx context.Context, client *web3go.Client, blockNunOrHash types.BlockNumberOrHash,
+) (EthReceiptMethod, error) {
+	for _, m := range receiptRetrievalMethods {
+		_, err := m.query(ctx, client, blockNunOrHash, DefaultReceiptOption)
+		if err == nil || errors.Is(err, ErrChainReorged) {
+			return m.method, nil
+		}
+
+		if !utils.IsRPCJSONError(err) {
+			// Potential I/O error
+			return 0, wrapDetectionError(err)
+		}
+	}
+
+	return 0, wrapDetectionError(errors.New("no available method succeeded"))
+}
+
+// wrapDetectionError adds context to receipt method detection errors
+func wrapDetectionError(err error) error {
+	return errors.WithMessage(err, "failed to detect receipt retrieval method")
+}
 
 // EthData wraps the evm space blockchain data.
 type EthData struct {
@@ -64,29 +195,41 @@ func GetBlockByBlockNumberOrHash(
 	return w3c.WithContext(ctx).Eth.BlockByHash(*bnh.BlockHash, isFull)
 }
 
-type EthReceiptRetrievalOption struct {
-	Method      EthReceiptRetrievalMethod
-	Concurrency int
-
-	// pre-fetched data can be used to accelerate the query eg., block header etc.
-	Prefetched interface{}
+func wrapReceiptMethodNotSupportedError(method EthReceiptMethod) error {
+	return errors.Errorf("receipt retrieval method %v not supported", method)
 }
 
 func QueryEthReceipt(
 	ctx context.Context,
 	w3c *web3go.Client,
 	bnh types.BlockNumberOrHash,
-	opt EthReceiptRetrievalOption,
+	opts ...EthReceiptOption,
 ) ([]*types.Receipt, error) {
+	// Use the default option unless an override is provided
+	opt := DefaultReceiptOption
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	// If the method is set to auto-detect or invalid, perform detection
+	if !opt.Method.IsConcrete() {
+		method, err := defaultRcptMethodDetector.Detect(ctx, w3c, bnh)
+		if err != nil {
+			return nil, err
+		}
+		opt.Method = method
+	}
+
+	// Retrieve receipts based on the specified method
 	switch opt.Method {
-	case EthReceiptRetrievalMethodParityBlockReceipts:
-		return queryEthReceiptByParityBlockReceipts(ctx, w3c, bnh)
-	case EthReceiptRetrievalMethodEthTxnReceipt:
+	case EthReceiptMethodParityBlockReceipts:
+		return queryEthReceiptByParityBlockReceipts(ctx, w3c, bnh, opt)
+	case EthReceiptMethodEthTxnReceipt:
 		return queryEthReceiptByEthTxnReceipt(ctx, w3c, bnh, opt)
-	case EthReceiptRetrievalMethodEthBlockReceipts:
-		return queryEthReceiptByEthBlockReceipts(ctx, w3c, bnh)
+	case EthReceiptMethodEthBlockReceipts:
+		return queryEthReceiptByEthBlockReceipts(ctx, w3c, bnh, opt)
 	default:
-		return nil, ErrReceiptRetrievalMethodNotSupported
+		return nil, wrapReceiptMethodNotSupportedError(opt.Method)
 	}
 }
 
@@ -95,12 +238,17 @@ func QueryEthData(
 	ctx context.Context,
 	w3c *web3go.Client,
 	blockNumber uint64,
-	rcptOpt EthReceiptRetrievalOption,
+	opts ...EthReceiptOption,
 ) (*EthData, error) {
 	updater := metrics.Registry.Sync.QueryEpochData("eth")
 	defer updater.Update()
 
-	data, err := queryEthData(ctx, w3c, blockNumber, rcptOpt)
+	opt := DefaultReceiptOption
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	data, err := queryEthData(ctx, w3c, blockNumber, opt)
 	metrics.Registry.Sync.QueryEpochDataAvailability("eth").
 		Mark(err == nil || errors.Is(err, ErrChainReorged))
 
@@ -111,7 +259,7 @@ func queryEthData(
 	ctx context.Context,
 	w3c *web3go.Client,
 	blockNumber uint64,
-	rcptOpt EthReceiptRetrievalOption,
+	rcptOpt EthReceiptOption,
 ) (*EthData, error) {
 	// Get block by number
 	block, err := w3c.Eth.BlockByNumber(types.BlockNumber(blockNumber), true)
@@ -142,8 +290,8 @@ func queryEthData(
 
 	for i := 0; i < len(blockTxs); i++ {
 		receipt := blockReceipts[i]
-		if err := validateEthTxnReceipt(block, i, receipt); err != nil {
-			return nil, errors.WithMessage(err, "failed to validate txn receipt")
+		if err := verifyEthTxnReceipt(block, i, receipt); err != nil {
+			return nil, errors.WithMessage(err, "failed to verify txn receipt")
 		}
 
 		txReceipts[blockTxs[i].Hash] = receipt
@@ -156,6 +304,7 @@ func queryEthReceiptByParityBlockReceipts(
 	ctx context.Context,
 	w3c *web3go.Client,
 	bnh types.BlockNumberOrHash,
+	rcptOpt EthReceiptOption,
 ) (receipts []*types.Receipt, err error) {
 	blockReceipts, err := w3c.WithContext(ctx).Parity.BlockReceipts(&bnh)
 	if err != nil {
@@ -169,11 +318,11 @@ func queryEthReceiptByParityBlockReceipts(
 	return receipts, nil
 }
 
-func newEthTxnRetrievalError(cause error, txnHash common.Hash) error {
+func wrapReceiptRetrievalError(cause error, txnHash common.Hash) error {
 	return errors.WithMessagef(cause, "failed to query receipt for txn %v", txnHash)
 }
 
-func validateEthTxnReceipt(block *types.Block, txnIndex int, receipt *types.Receipt) error {
+func verifyEthTxnReceipt(block *types.Block, txnIndex int, receipt *types.Receipt) error {
 	// sanity check in case of chain re-org
 	switch {
 	case receipt == nil: // receipt shouldn't be nil unless chain re-org
@@ -191,13 +340,14 @@ func validateEthTxnReceipt(block *types.Block, txnIndex int, receipt *types.Rece
 			receipt.BlockNumber, block.Nonce.Uint64(), txnIndex,
 		)
 	default:
-		txnHashes := getBlockTxnHashes(block)
+		txnHashes := getEthBlockTxnHashes(block)
 		if len(txnHashes) <= txnIndex {
-			return errors.Errorf(
-				"failed to match txn %v within block %v due to index %v out of bound",
+			return errors.WithMessagef(
+				ErrChainReorged, "failed to match txn %v within block %v due to index %v out of bound",
 				receipt.TransactionHash, block.Hash, txnIndex,
 			)
 		}
+
 		if th := txnHashes[txnIndex]; th != receipt.TransactionHash {
 			return errors.WithMessagef(
 				ErrChainReorged, "receipt tx hash %v mismatch for txn %v within block %v at index %v",
@@ -208,7 +358,7 @@ func validateEthTxnReceipt(block *types.Block, txnIndex int, receipt *types.Rece
 	}
 }
 
-func getBlockTxnHashes(block *types.Block) (txnHashes []common.Hash) {
+func getEthBlockTxnHashes(block *types.Block) (txnHashes []common.Hash) {
 	if block.Transactions.Type() == types.TXLIST_HASH {
 		return block.Transactions.Hashes()
 	}
@@ -224,7 +374,7 @@ func queryEthReceiptByEthTxnReceipt(
 	ctx context.Context,
 	w3c *web3go.Client,
 	bnh types.BlockNumberOrHash,
-	rcptOpt EthReceiptRetrievalOption,
+	rcptOpt EthReceiptOption,
 ) (receipts []*types.Receipt, err error) {
 	block, ok := rcptOpt.Prefetched.(*types.Block)
 	if !ok || block == nil {
@@ -233,7 +383,7 @@ func queryEthReceiptByEthTxnReceipt(
 			return nil, errors.WithMessage(err, "failed to get block by block number or hash")
 		}
 	}
-	txnHashes := getBlockTxnHashes(block)
+	txnHashes := getEthBlockTxnHashes(block)
 
 	if rcptOpt.Concurrency == 0 {
 		for i := 0; i < len(txnHashes); i++ {
@@ -245,11 +395,11 @@ func queryEthReceiptByEthTxnReceipt(
 					"txnHash":     txnHashes[i],
 					"txnIndex":    i,
 				}).WithError(err).Info("Failed to query eth transaction receipt")
-				return nil, newEthTxnRetrievalError(err, txnHashes[i])
+				return nil, wrapReceiptRetrievalError(err, txnHashes[i])
 			}
 
-			if err := validateEthTxnReceipt(block, i, receipt); err != nil {
-				return nil, errors.WithMessage(err, "failed to validate transaction receipt")
+			if err := verifyEthTxnReceipt(block, i, receipt); err != nil {
+				return nil, errors.WithMessage(err, "failed to verify transaction receipt")
 			}
 			receipts = append(receipts, receipt)
 		}
@@ -269,11 +419,11 @@ func queryEthReceiptByEthTxnReceipt(
 		errGrp.Go(func() error {
 			receipt, err := w3c.WithContext(ctx).Eth.TransactionReceipt(txnHash)
 			if err != nil {
-				return newEthTxnRetrievalError(err, txnHash)
+				return wrapReceiptRetrievalError(err, txnHash)
 			}
 
-			if err := validateEthTxnReceipt(block, rcptIdx, receipt); err != nil {
-				return errors.WithMessage(err, "failed to validate transaction receipt")
+			if err := verifyEthTxnReceipt(block, rcptIdx, receipt); err != nil {
+				return errors.WithMessage(err, "failed to verify transaction receipt")
 			}
 
 			// Thread safe to write here since receipt index is unique for each goroutine within the group.
@@ -300,6 +450,7 @@ func queryEthReceiptByEthBlockReceipts(
 	ctx context.Context,
 	w3c *web3go.Client,
 	bnh types.BlockNumberOrHash,
+	rcptOpt EthReceiptOption,
 ) ([]*types.Receipt, error) {
 	blockReceipts, err := w3c.WithContext(ctx).Eth.BlockReceipts(&bnh)
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -169,4 +169,5 @@ func MustInit() {
 	ethStoreConfig.mustInit("ethstore")
 
 	initLogFilter()
+	initEth()
 }

--- a/sync/sync_eth.go
+++ b/sync/sync_eth.go
@@ -23,10 +23,8 @@ import (
 )
 
 type syncEthConfig struct {
-	RcptRetrievalMethod      int
-	RcptRetrievalConcurrency int    `default:"4"`
-	FromBlock                uint64 `default:"1"`
-	MaxBlocks                uint64 `default:"10"`
+	FromBlock uint64 `default:"1"`
+	MaxBlocks uint64 `default:"10"`
 }
 
 // EthSyncer is used to synchronize evm space blockchain data into db store.
@@ -179,17 +177,12 @@ func (syncer *EthSyncer) syncOnce(ctx context.Context) (bool, error) {
 
 	logger.Debug("ETH syncer started to sync with block range")
 
-	rcptOption := store.EthReceiptRetrievalOption{
-		Method:      store.EthReceiptRetrievalMethod(syncer.conf.RcptRetrievalMethod),
-		Concurrency: syncer.conf.RcptRetrievalConcurrency,
-	}
-
 	ethDataSlice := make([]*store.EthData, 0, syncSize)
 	for i := uint64(0); i < syncSize; i++ {
 		blockNo := syncer.fromBlock + uint64(i)
 		blogger := logger.WithField("block", blockNo)
 
-		data, err := store.QueryEthData(ctx, syncer.w3c, blockNo, rcptOption)
+		data, err := store.QueryEthData(ctx, syncer.w3c, blockNo)
 
 		// If chain re-orged, stop the querying right now since it's pointless to query data
 		// that will be reverted late.


### PR DESCRIPTION
- Implemented options for `eth_getTransactionReceipt`, `parity_getBlockReceipts`, and `eth_getBlockReceipts`.
- Introduced concurrency settings and improved error handling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/227)
<!-- Reviewable:end -->
