### PR TITLE
Optimize receipt and log handling in ETH sync

### DIFF
--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -20,7 +20,7 @@ var (
 )
 
 type StoreOption struct {
-	Disabler store.StoreDisabler
+	Disabler store.ChainDataDisabler
 }
 
 // MysqlStore aggregation store for chain data persistence operation.
@@ -42,7 +42,7 @@ type MysqlStore struct {
 	// config
 	config *Config
 	// store chaindata disabler
-	disabler store.StoreDisabler
+	disabler store.ChainDataDisabler
 	// store pruner
 	pruner *storePruner
 }

--- a/store/redis/store.go
+++ b/store/redis/store.go
@@ -33,10 +33,10 @@ type RedisStore struct {
 	ctx       context.Context
 	rdb       *redis.Client
 	cacheTime time.Duration
-	disabler  store.StoreDisabler
+	disabler  store.ChainDataDisabler
 }
 
-func MustNewRedisStoreFromViper(disabler store.StoreDisabler) (*RedisStore, bool) {
+func MustNewRedisStoreFromViper(disabler store.ChainDataDisabler) (*RedisStore, bool) {
 	var rsconf RedisStoreConfig
 	viper.MustUnmarshalKey("store.redis", &rsconf)
 

--- a/store/store.go
+++ b/store/store.go
@@ -96,7 +96,7 @@ func EthStoreConfig() *storeConfig {
 	return &ethStoreConfig
 }
 
-type StoreDisabler interface {
+type ChainDataDisabler interface {
 	IsChainBlockDisabled() bool
 	IsChainTxnDisabled() bool
 	IsChainReceiptDisabled() bool


### PR DESCRIPTION
- Use `eth_getLogs` for fetching event logs when receipts are disabled, improving performance.
- Return only block data if both receipts and logs are disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/230)
<!-- Reviewable:end -->
