### PR TITLE
fix: fix slice init length

### DIFF
--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -131,7 +131,7 @@ func (bcls *bigContractLogStore) migrate(contract *Contract, partition bnPartiti
 
 		aidb := dbTx.Table(aiTableName).Where("cid = ?", contract.ID)
 		res := aidb.FindInBatches(&aiLogs, defaultBatchSizeLogInsert, func(tx *gorm.DB, batch int) error {
-			deleteIds := make([]uint64, len(aiLogs))
+			deleteIds := make([]uint64, 0, len(aiLogs))
 			clLogs := make([]*contractLog, 0, len(aiLogs))
 
 			for _, aiLog := range aiLogs {


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of  `len(aiLogs)`  rather than initializing the len(units) of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/238)
<!-- Reviewable:end -->
