### PR TITLE
Disable bound checks if no possible narrower log filter

### DIFF
--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -118,12 +119,18 @@ func (handler *CfxLogsApiHandler) getLogsReorgGuard(
 	var logs []types.Log
 	var accumulator int
 
+	useBoundCheck := handler.RequireBoundChecks(filter)
 	if len(dbFilters) > 0 {
-		// add db query timeout
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
-		defer cancel()
+		if useBoundCheck {
+			// add db query timeout
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
+			defer cancel()
+		} else {
+			ctx = store.NewContextWithBoundChecksDisabled(ctx)
+		}
 	}
+
 	// query data from database
 	for i := range dbFilters {
 		if err := checkTimeout(ctx); err != nil {
@@ -135,9 +142,8 @@ func (handler *CfxLogsApiHandler) getLogsReorgGuard(
 		// succeeded to get logs from database
 		if err == nil {
 			for _, v := range dbLogs {
-				accumulator, err = handler.accumulateBodySizeOfLogs(cfx, filter, accumulator, v)
-				if err != nil {
-					return nil, false, err
+				if accumulator += len(v.Extra); useBoundCheck && uint64(accumulator) > maxGetLogsResponseBytes {
+					return nil, false, newSuggestedBodyBytesOversizedError(cfx, filter, v)
 				}
 
 				log, _ := v.ToCfxLog()
@@ -184,8 +190,8 @@ func (handler *CfxLogsApiHandler) getLogsReorgGuard(
 		}
 
 		for i := range fnLogs {
-			if accumulator, err = handler.accumulateBodySizeOfCfxLogs(cfx, filter, accumulator, fnLogs[i]); err != nil {
-				return nil, false, err
+			if accumulator += len(fnLogs[i].Data); useBoundCheck && uint64(accumulator) > maxGetLogsResponseBytes {
+				return nil, false, newSuggestedBodyBytesOversizedError(cfx, filter, &fnLogs[i])
 			}
 		}
 		logs = append(logs, fnLogs...)
@@ -209,16 +215,28 @@ func (handler *CfxLogsApiHandler) getLogsReorgGuard(
 		}
 
 		for i := range fnLogs {
-			if accumulator, err = handler.accumulateBodySizeOfCfxLogs(cfx, filter, accumulator, fnLogs[i]); err != nil {
-				return nil, false, err
+			if accumulator += len(fnLogs[i].Data); useBoundCheck && uint64(accumulator) > maxGetLogsResponseBytes {
+				return nil, false, newSuggestedBodyBytesOversizedError(cfx, filter, &fnLogs[i])
 			}
 		}
 		logs = append(logs, fnLogs...)
 	}
 
 	// ensure result set never oversized
-	if len(logs) > int(store.MaxLogLimit) {
-		return nil, false, store.ErrFilterResultSetTooLarge
+	if useBoundCheck && len(logs) > int(store.MaxLogLimit) {
+		return nil, false, newSuggestedResultSetOversizedError(cfx, filter, &logs[store.MaxLogLimit])
+	}
+
+	// Rare case: log context information for diagnostic purposes if the result exceeds limits.
+	if uint64(len(logs)) > store.MaxLogLimit || uint64(accumulator) > maxGetLogsResponseBytes {
+		logrus.WithFields(logrus.Fields{
+			"logFilter":         filter,
+			"databaseFilters":   dbFilters,
+			"functionFilter":    fnFilter,
+			"boundCheckEnabled": useBoundCheck,
+			"resultSetCount":    len(logs),
+			"responseSizeBytes": uint64(accumulator),
+		}).Info("Exceeded limits for getLogs response")
 	}
 
 	return logs, len(dbFilters) > 0, nil
@@ -467,41 +485,40 @@ func (handler *CfxLogsApiHandler) convertSuggestedFilterOversizedError(
 	return store.NewSuggestedFilterOversizeError(oversizedErr.Unwrap(), suggestedEpochRange)
 }
 
-// Accumulate body size and suggest range if exceeded
-func (handler *CfxLogsApiHandler) accumulateBodySizeOfLogs(cfx sdk.ClientOperator, filter *types.LogFilter, accumulator int, logs ...*store.Log) (int, error) {
-	for _, log := range logs {
-		accumulator += len(log.Extra)
-		if uint64(accumulator) > maxGetLogsResponseBytes {
-			return accumulator, newSuggestedBodyBytesOversizedError(cfx, filter, *log)
-		}
+// RequireBoundChecks determines if bound checks should be applied based on if there is any space to narrow down the log filter
+func (handler *CfxLogsApiHandler) RequireBoundChecks(filter *types.LogFilter) bool {
+	switch {
+	case filter.FromEpoch != nil && filter.ToEpoch != nil:
+		return !filter.FromEpoch.Equals(filter.ToEpoch)
+	case filter.FromBlock != nil && filter.ToBlock != nil:
+		return filter.FromBlock.ToInt().Cmp(filter.ToBlock.ToInt()) < 0
+	default:
+		return len(filter.BlockHashes) > 1
 	}
-	return accumulator, nil
 }
 
-// Accumulate body size and suggest range if exceeded for CfxLogs
-func (handler *CfxLogsApiHandler) accumulateBodySizeOfCfxLogs(
-	cfx sdk.ClientOperator, filter *types.LogFilter, accumulator int, logs ...types.Log) (int, error) {
-
-	for _, log := range logs {
-		accumulator += len(log.Data)
-		if uint64(accumulator) > maxGetLogsResponseBytes {
-			return accumulator, newSuggestedBodyBytesOversizedError(cfx, filter, log)
-		}
-	}
-	return accumulator, nil
+func newSuggestedBodyBytesOversizedError[T types.Log | store.Log](
+	cfx sdk.ClientOperator, filter *types.LogFilter, exceedingLog *T) error {
+	return newSuggestedFilterOversizedError[T](errResponseBodySizeTooLarge, cfx, filter, exceedingLog)
 }
 
-func newSuggestedBodyBytesOversizedError[T types.Log | store.Log](cfx sdk.ClientOperator, filter *types.LogFilter, firstExceedingLog T) error {
+func newSuggestedResultSetOversizedError[T types.Log | store.Log](
+	cfx sdk.ClientOperator, filter *types.LogFilter, exceedingLog *T) error {
+	return newSuggestedFilterOversizedError[T](store.ErrFilterResultSetTooLarge, cfx, filter, exceedingLog)
+}
+
+func newSuggestedFilterOversizedError[T types.Log | store.Log](
+	inner error, cfx sdk.ClientOperator, filter *types.LogFilter, exceedingLog *T) error {
+
 	var logEpochNum, logBlockNum uint64
-
-	switch v := any(firstExceedingLog).(type) {
-	case store.Log:
+	switch v := any(exceedingLog).(type) {
+	case *store.Log:
 		if filter.FromEpoch != nil {
 			logEpochNum = v.Epoch
 		} else if filter.FromBlock != nil {
 			logBlockNum = v.BlockNumber
 		}
-	case types.Log:
+	case *types.Log:
 		if filter.FromEpoch != nil {
 			logEpochNum = v.EpochNumber.ToInt().Uint64()
 		} else if filter.FromBlock != nil && v.BlockHash != nil {
@@ -513,7 +530,7 @@ func newSuggestedBodyBytesOversizedError[T types.Log | store.Log](cfx sdk.Client
 
 	// Return early if no valid `logEpochNum` or `logBlockNum` is found
 	if logEpochNum == 0 && logBlockNum == 0 {
-		return errResponseBodySizeTooLarge
+		return inner
 	}
 
 	// Suggest filter adjustments based on `FromEpoch` or `FromBlock`
@@ -521,7 +538,7 @@ func newSuggestedBodyBytesOversizedError[T types.Log | store.Log](cfx sdk.Client
 		fromEpoch, _ := filter.FromEpoch.ToInt()
 		if logEpochNum > fromEpoch.Uint64() {
 			return store.NewSuggestedFilterOversizeError(
-				errResponseBodySizeTooLarge,
+				inner,
 				store.NewSuggestedEpochRange(fromEpoch.Uint64(), logEpochNum-1),
 			)
 		}
@@ -529,13 +546,13 @@ func newSuggestedBodyBytesOversizedError[T types.Log | store.Log](cfx sdk.Client
 		fromBlock := filter.FromBlock.ToInt()
 		if logBlockNum > fromBlock.Uint64() {
 			return store.NewSuggestedFilterOversizeError(
-				errResponseBodySizeTooLarge,
+				inner,
 				store.NewSuggestedBlockRange(fromBlock.Uint64(), logBlockNum-1, 0),
 			)
 		}
 	}
 
-	return errResponseBodySizeTooLarge
+	return inner
 }
 
 // checkTimeout checks if operation is timed out.

--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -223,7 +223,7 @@ func (handler *CfxLogsApiHandler) getLogsReorgGuard(
 	}
 
 	// ensure result set never oversized
-	if useBoundCheck && len(logs) > int(store.MaxLogLimit) {
+	if useBoundCheck && uint64(len(logs)) > store.MaxLogLimit {
 		return nil, false, newSuggestedResultSetOversizedError(cfx, filter, &logs[store.MaxLogLimit])
 	}
 

--- a/rpc/handler/eth_logs.go
+++ b/rpc/handler/eth_logs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/openweb3/web3go/client"
 	"github.com/openweb3/web3go/types"
+	"github.com/sirupsen/logrus"
 )
 
 // EthLogsApiHandler RPC handler to get evm space event logs from store or fullnode.
@@ -89,13 +90,18 @@ func (handler *EthLogsApiHandler) getLogsReorgGuard(
 	var logs []types.Log
 	var accumulator int
 
-	// query data from database
+	useBoundCheck := handler.RequiresBoundChecks(filter)
 	if dbFilter != nil {
-		// add db query timeout
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
-		defer cancel()
+		if useBoundCheck {
+			// add db query timeout
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
+			defer cancel()
+		} else {
+			ctx = store.NewContextWithBoundChecksDisabled(ctx)
+		}
 
+		// query data from database
 		dbLogs, err := handler.ms.GetLogs(ctx, *dbFilter)
 		if err != nil {
 			// TODO ErrPrunedAlready
@@ -103,8 +109,8 @@ func (handler *EthLogsApiHandler) getLogsReorgGuard(
 		}
 
 		for _, v := range dbLogs {
-			if accumulator, err = handler.accumulateBodySizeOfLogs(filter, accumulator, v); err != nil {
-				return nil, false, err
+			if accumulator += len(v.Extra); useBoundCheck && uint64(accumulator) > maxGetLogsResponseBytes {
+				return nil, false, handler.newSuggestedBodyBytesOversizedError(filter, v.BlockNumber)
 			}
 
 			cfxLog, ext := v.ToCfxLog()
@@ -130,15 +136,29 @@ func (handler *EthLogsApiHandler) getLogsReorgGuard(
 		}
 
 		for i := range fnLogs {
-			if accumulator, err = handler.accumulateBodySizeOfEthLogs(filter, accumulator, fnLogs[i]); err != nil {
-				return nil, false, err
+			if accumulator += len(fnLogs[i].Data); useBoundCheck && uint64(accumulator) > maxGetLogsResponseBytes {
+				return nil, false, handler.newSuggestedBodyBytesOversizedError(filter, fnLogs[i].BlockNumber)
 			}
 		}
 		logs = append(logs, fnLogs...)
 	}
 
-	if len(logs) > int(store.MaxLogLimit) {
-		return nil, false, store.ErrFilterResultSetTooLarge
+	// ensure result set never oversized
+	if useBoundCheck && len(logs) > int(store.MaxLogLimit) {
+		exceedingBlockNum := logs[store.MaxLogLimit].BlockNumber
+		return nil, false, handler.newSuggestedResultSetOversizedError(filter, exceedingBlockNum)
+	}
+
+	// Rare case: log context information for diagnostic purposes if the result exceeds limits.
+	if uint64(len(logs)) > store.MaxLogLimit || uint64(accumulator) > maxGetLogsResponseBytes {
+		logrus.WithFields(logrus.Fields{
+			"logFilter":         filter,
+			"databaseFilter":    dbFilter,
+			"functionFilter":    fnFilter,
+			"boundCheckEnabled": useBoundCheck,
+			"resultSetCount":    len(logs),
+			"responseSizeBytes": uint64(accumulator),
+		}).Info("Exceeded limits for getLogs response")
 	}
 
 	return logs, dbFilter != nil, nil
@@ -269,43 +289,31 @@ func (handler *EthLogsApiHandler) checkFnEthLogFilter(filter *types.FilterQuery)
 	return nil
 }
 
-// Accumulate body size and suggest range if exceeded
-func (handler *EthLogsApiHandler) accumulateBodySizeOfLogs(filter *types.FilterQuery, accumulator int, logs ...*store.Log) (int, error) {
-	for _, log := range logs {
-		accumulator += len(log.Extra)
-		if uint64(accumulator) > maxGetLogsResponseBytes {
-			return accumulator, handler.newSuggestedBodyBytesOversizedError(filter, log.BlockNumber)
-		}
+// RequiresBoundChecks determines if bound checks should be applied based on if there is any space to narrow down the log filter
+func (handler *EthLogsApiHandler) RequiresBoundChecks(filter *types.FilterQuery) bool {
+	if filter.FromBlock != nil && filter.ToBlock != nil {
+		return *filter.FromBlock < *filter.ToBlock
 	}
-	return accumulator, nil
+	return false
 }
 
-// Accumulate body size and suggest range if exceeded for CfxLogs
-func (handler *EthLogsApiHandler) accumulateBodySizeOfEthLogs(filter *types.FilterQuery, accumulator int, logs ...types.Log) (int, error) {
-
-	for _, log := range logs {
-		accumulator += len(log.Data)
-		if uint64(accumulator) > maxGetLogsResponseBytes {
-			return accumulator, handler.newSuggestedBodyBytesOversizedError(filter, log.BlockNumber)
-		}
-	}
-	return accumulator, nil
+func (handler *EthLogsApiHandler) newSuggestedResultSetOversizedError(filter *types.FilterQuery, exceedingBlockNum uint64) error {
+	return handler.newSuggestedFilterOversizedError(store.ErrFilterResultSetTooLarge, filter, exceedingBlockNum)
 }
 
-func (handler *EthLogsApiHandler) newSuggestedBodyBytesOversizedError(filter *types.FilterQuery, firstExceedingBlockNum uint64) error {
-	if filter.FromBlock == nil {
-		return errResponseBodySizeTooLarge
+func (handler *EthLogsApiHandler) newSuggestedBodyBytesOversizedError(filter *types.FilterQuery, exceedingBlockNum uint64) error {
+	return handler.newSuggestedFilterOversizedError(errResponseBodySizeTooLarge, filter, exceedingBlockNum)
+}
+
+func (handler *EthLogsApiHandler) newSuggestedFilterOversizedError(inner error, filter *types.FilterQuery, exceedingBlockNum uint64) error {
+	if filter.FromBlock != nil {
+		fromBlock := uint64(*filter.FromBlock)
+		if exceedingBlockNum > fromBlock {
+			return store.NewSuggestedFilterOversizeError(inner, store.NewSuggestedBlockRange(fromBlock, exceedingBlockNum-1, 0))
+		}
 	}
 
-	fromBlock := uint64(*filter.FromBlock)
-	if firstExceedingBlockNum > fromBlock {
-		return store.NewSuggestedFilterOversizeError(
-			errResponseBodySizeTooLarge,
-			store.NewSuggestedBlockRange(fromBlock, firstExceedingBlockNum-1, 0),
-		)
-	}
-
-	return errResponseBodySizeTooLarge
+	return inner
 }
 
 // calculateEthBlockRange calculates the block range of the log filter and returns the gap and a boolean indicating success.

--- a/rpc/handler/eth_logs.go
+++ b/rpc/handler/eth_logs.go
@@ -144,7 +144,7 @@ func (handler *EthLogsApiHandler) getLogsReorgGuard(
 	}
 
 	// ensure result set never oversized
-	if useBoundCheck && len(logs) > int(store.MaxLogLimit) {
+	if useBoundCheck && uint64(len(logs)) > store.MaxLogLimit {
 		exceedingBlockNum := logs[store.MaxLogLimit].BlockNumber
 		return nil, false, handler.newSuggestedResultSetOversizedError(filter, exceedingBlockNum)
 	}

--- a/store/log_filter.go
+++ b/store/log_filter.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -41,6 +42,22 @@ var ( // Log filter constants
 	MaxLogEpochRange uint64
 	MaxLogBlockRange uint64
 )
+
+// Custom type for the context key to avoid collisions
+type contextKey string
+
+const boundChecksDisabledKey contextKey = "Bound-Checks-Disabled"
+
+// NewContextWithBoundChecksDisabled returns a context that marks bound checks as disabled for getLogs
+func NewContextWithBoundChecksDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, boundChecksDisabledKey, struct{}{})
+}
+
+// IsBoundChecksEnabled checks if bound checks are enabled for getLogs
+// Defaults to true if not explicitly disabled
+func IsBoundChecksEnabled(ctx context.Context) bool {
+	return ctx.Value(boundChecksDisabledKey) != nil
+}
 
 type SuggestedBlockRange struct {
 	citypes.RangeUint64

--- a/store/log_filter.go
+++ b/store/log_filter.go
@@ -56,7 +56,7 @@ func NewContextWithBoundChecksDisabled(ctx context.Context) context.Context {
 // IsBoundChecksEnabled checks if bound checks are enabled for getLogs
 // Defaults to true if not explicitly disabled
 func IsBoundChecksEnabled(ctx context.Context) bool {
-	return ctx.Value(boundChecksDisabledKey) != nil
+	return ctx.Value(boundChecksDisabledKey) == nil
 }
 
 type SuggestedBlockRange struct {

--- a/store/mysql/store_common_partition_bn.go
+++ b/store/mysql/store_common_partition_bn.go
@@ -211,7 +211,8 @@ func (bnps *bnPartitionedStore) searchPartitions(entity string, searchRange type
 // searchOverlapPartitions search entity partitions that overlap the search range regardless of the boundary.
 func (bnps *bnPartitionedStore) searchOverlapPartitions(entity string, searchRange types.RangeUint64) ([]*bnPartition, error) {
 	db := bnps.db.Where("entity = ?", entity).
-		Where("bn_min <= ? AND bn_max >= ?", searchRange.To, searchRange.From)
+		Where("bn_min <= ? AND bn_max >= ?", searchRange.To, searchRange.From).
+		Order("pi asc")
 
 	var partitions []*bnPartition
 	err := db.Find(&partitions).Error

--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -195,7 +195,7 @@ func (ls *logStore) GetLogs(ctx context.Context, storeFilter store.LogFilter) ([
 		default:
 		}
 
-		logs, err := ls.GetBnPartitionedLogs(filter, *partition)
+		logs, err := ls.GetBnPartitionedLogs(ctx, filter, *partition)
 		if err != nil {
 			return nil, err
 		}
@@ -206,8 +206,8 @@ func (ls *logStore) GetLogs(ctx context.Context, storeFilter store.LogFilter) ([
 		}
 
 		// check log count
-		if len(result) > int(store.MaxLogLimit) {
-			return nil, store.ErrFilterResultSetTooLarge
+		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
+			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, store.MaxLogLimit, true)
 		}
 	}
 
@@ -215,11 +215,11 @@ func (ls *logStore) GetLogs(ctx context.Context, storeFilter store.LogFilter) ([
 }
 
 // GetBnPartitionedLogs returns event logs for the specified block number partitioned log filter.
-func (ls *logStore) GetBnPartitionedLogs(filter LogFilter, partition bnPartition) ([]*log, error) {
+func (ls *logStore) GetBnPartitionedLogs(ctx context.Context, filter LogFilter, partition bnPartition) ([]*log, error) {
 	filter.TableName = ls.getPartitionedTableName(&log{}, partition.Index)
 
 	var res []*log
-	err := filter.find(ls.db, &res)
+	err := filter.find(ctx, ls.db, &res)
 
 	return res, err
 }

--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -207,7 +207,7 @@ func (ls *logStore) GetLogs(ctx context.Context, storeFilter store.LogFilter) ([
 
 		// check log count
 		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, store.MaxLogLimit, true)
+			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, true)
 		}
 	}
 

--- a/store/mysql/store_log_addr.go
+++ b/store/mysql/store_log_addr.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 
@@ -178,11 +179,12 @@ func (ls *AddressIndexedLogStore) DeleteAddressIndexedLogs(dbTx *gorm.DB, epochF
 
 // GetAddressIndexedLogs returns event logs for the specified filter.
 func (ls *AddressIndexedLogStore) GetAddressIndexedLogs(
+	ctx context.Context,
 	filter AddressIndexedLogFilter,
 	contract string,
 ) ([]*AddressIndexedLog, error) {
 	filter.TableName = ls.GetPartitionedTableName(contract)
-	return filter.Find(ls.db)
+	return filter.Find(ctx, ls.db)
 }
 
 // GetPartitionedTableName returns partitioned table name with specified

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -410,7 +410,7 @@ func (bcls *bigContractLogStore) GetContractLogs(
 
 		// check log count
 		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, store.MaxLogLimit, true)
+			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, true)
 		}
 	}
 

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -396,7 +396,7 @@ func (bcls *bigContractLogStore) GetContractLogs(
 		default:
 		}
 
-		logs, err := bcls.GetContractBnPartitionedLogs(cid, filter, *partition)
+		logs, err := bcls.GetContractBnPartitionedLogs(ctx, cid, filter, *partition)
 		if err != nil {
 			return nil, err
 		}
@@ -409,8 +409,8 @@ func (bcls *bigContractLogStore) GetContractLogs(
 		}
 
 		// check log count
-		if len(result) > int(store.MaxLogLimit) {
-			return nil, store.ErrFilterResultSetTooLarge
+		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
+			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, store.MaxLogLimit, true)
 		}
 	}
 
@@ -420,13 +420,13 @@ func (bcls *bigContractLogStore) GetContractLogs(
 // GetContractBnPartitionedLogs returns contract event logs for the log filter from
 // specified table partition ranged by block number.
 func (bcls *bigContractLogStore) GetContractBnPartitionedLogs(
-	cid uint64, filter LogFilter, partition bnPartition,
+	ctx context.Context, cid uint64, filter LogFilter, partition bnPartition,
 ) ([]*contractLog, error) {
 	contractTabler := bcls.contractTabler(cid)
 	filter.TableName = bcls.getPartitionedTableName(contractTabler, partition.Index)
 
 	var res []*contractLog
-	err := filter.find(bcls.db, &res)
+	err := filter.find(ctx, bcls.db, &res)
 
 	return res, err
 }

--- a/store/mysql/store_log_filter.go
+++ b/store/mysql/store_log_filter.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Conflux-Chain/confura/store"
@@ -226,27 +227,30 @@ func (filter *LogFilter) hasTopicsFilter() bool {
 	return false
 }
 
-func (filter *LogFilter) find(db *gorm.DB, destSlicePtr interface{}) error {
-	if err := filter.validateQuerySetSize(db); err != nil {
-		return err
+func (filter *LogFilter) find(ctx context.Context, db *gorm.DB, destSlicePtr interface{}) error {
+	if store.IsBoundChecksEnabled(ctx) {
+		if err := filter.validateQuerySetSize(db); err != nil {
+			return err
+		}
 	}
 
 	db = db.Table(filter.TableName)
 	db = db.Where("bn BETWEEN ? AND ?", filter.BlockFrom, filter.BlockTo)
 	db = applyTopicsFilter(db, filter.Topics)
+	db = db.Order("bn ASC")
 	db = db.Limit(int(store.MaxLogLimit) + 1)
 
 	return db.Find(destSlicePtr).Error
 }
 
 // TODO add method FindXxx for type safety and double check the result set size <= max_limit.
-func (filter *LogFilter) Find(db *gorm.DB) ([]int, error) {
+func (filter *LogFilter) Find(ctx context.Context, db *gorm.DB) ([]int, error) {
 	var result []int
-	if err := filter.find(db, &result); err != nil {
+	if err := filter.find(ctx, db, &result); err != nil {
 		return nil, err
 	}
 
-	if len(result) > int(store.MaxLogLimit) {
+	if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
 		return nil, store.ErrFilterResultSetTooLarge
 	}
 
@@ -265,14 +269,17 @@ func (filter *AddressIndexedLogFilter) validateCount(db *gorm.DB) error {
 	return filter.LogFilter.validateCount(db)
 }
 
-func (filter *AddressIndexedLogFilter) Find(db *gorm.DB) ([]*AddressIndexedLog, error) {
-	if err := filter.validateCount(db); err != nil {
-		return nil, err
+func (filter *AddressIndexedLogFilter) Find(ctx context.Context, db *gorm.DB) ([]*AddressIndexedLog, error) {
+	if store.IsBoundChecksEnabled(ctx) {
+		if err := filter.validateCount(db); err != nil {
+			return nil, err
+		}
 	}
 
 	db = db.Table(filter.TableName).
 		Where("cid = ?", filter.ContractId).
 		Where("bn BETWEEN ? AND ?", filter.BlockFrom, filter.BlockTo).
+		Order("bn ASC").
 		Limit(int(store.MaxLogLimit) + 1)
 	db = applyTopicsFilter(db, filter.Topics)
 
@@ -281,7 +288,7 @@ func (filter *AddressIndexedLogFilter) Find(db *gorm.DB) ([]*AddressIndexedLog, 
 		return nil, err
 	}
 
-	if len(result) > int(store.MaxLogLimit) {
+	if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
 		return nil, store.ErrFilterResultSetTooLarge
 	}
 

--- a/store/mysql/store_log_filter.go
+++ b/store/mysql/store_log_filter.go
@@ -243,20 +243,6 @@ func (filter *LogFilter) find(ctx context.Context, db *gorm.DB, destSlicePtr int
 	return db.Find(destSlicePtr).Error
 }
 
-// TODO add method FindXxx for type safety and double check the result set size <= max_limit.
-func (filter *LogFilter) Find(ctx context.Context, db *gorm.DB) ([]int, error) {
-	var result []int
-	if err := filter.find(ctx, db, &result); err != nil {
-		return nil, err
-	}
-
-	if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-		return nil, store.ErrFilterResultSetTooLarge
-	}
-
-	return result, nil
-}
-
 // AddressIndexedLogFilter is used to query event logs that indexed by contract id and block number.
 type AddressIndexedLogFilter struct {
 	LogFilter
@@ -286,10 +272,6 @@ func (filter *AddressIndexedLogFilter) Find(ctx context.Context, db *gorm.DB) ([
 	var result []*AddressIndexedLog
 	if err := db.Find(&result).Error; err != nil {
 		return nil, err
-	}
-
-	if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-		return nil, store.ErrFilterResultSetTooLarge
 	}
 
 	return result, nil


### PR DESCRIPTION
- Fetch as many event logs as possible when bound checks are disabled.
- Add further filter range suggestions for cases when merging event logs from multiple contract addresses within the log filter or from multiple database table partitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/244)
<!-- Reviewable:end -->
