### PR TITLE
Use `cfx_getLogs` to accelerate catch-up sync

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -126,6 +126,10 @@ sync:
   #   maxDbRows: 7500
   #   # Capacity of channel per worker to buffer queried epoch data
   #   workerChanSize: 5
+  #   # Number of epochs to sync per batch for each worker.
+  #   # Increase this value to sync more epochs once to improve performance,
+  #   # but may increase the memory usage accordingly.
+  #   syncBatchSize: 1
 
   # # EVM space sync configurations
   # eth:

--- a/sync/catchup/config.go
+++ b/sync/catchup/config.go
@@ -9,4 +9,6 @@ type config struct {
 	MaxDbRows int `default:"7500"`
 	// capacity of channel per worker to buffer queried epoch data
 	WorkerChanSize int `default:"5"`
+	// number of epochs to sync per batch
+	SyncBatchSize int `default:"1"`
 }

--- a/sync/catchup/syncer.go
+++ b/sync/catchup/syncer.go
@@ -123,9 +123,12 @@ func (s *Syncer) Sync(ctx context.Context) {
 		logrus.Debug("Catch-up syncer skipped due to no workers configured")
 		return
 	}
+	s.batchSize = max(1, s.batchSize)
 
-	logrus.WithField("numWorkers", len(s.workers)).
-		Debug("Catch-up syncer starting to catch up latest epoch")
+	logrus.WithFields(logrus.Fields{
+		"numWorkers": len(s.workers),
+		"batchSize":  s.batchSize,
+	}).Debug("Catch-up syncer starting to catch up latest epoch")
 
 	etLogger := logutil.NewErrorTolerantLogger(logutil.DefaultETConfig)
 	for s.elm.Await(ctx) {

--- a/sync/catchup/worker.go
+++ b/sync/catchup/worker.go
@@ -6,9 +6,13 @@ import (
 	"time"
 
 	"github.com/Conflux-Chain/confura/store"
+	"github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/Conflux-Chain/confura/util/rpc"
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
+	"github.com/Conflux-Chain/go-conflux-sdk/types"
 	logutil "github.com/Conflux-Chain/go-conflux-util/log"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,7 +20,7 @@ type worker struct {
 	// worker name
 	name string
 	// result channel to collect queried epoch data
-	resultChan chan *store.EpochData
+	resultChan chan []*store.EpochData
 	// conflux sdk client delegated to fetch epoch data
 	cfx sdk.ClientOperator
 }
@@ -24,12 +28,13 @@ type worker struct {
 func mustNewWorker(name, nodeUrl string, chanSize int) *worker {
 	return &worker{
 		name:       name,
-		resultChan: make(chan *store.EpochData, chanSize),
+		resultChan: make(chan []*store.EpochData, chanSize),
 		cfx:        rpc.MustNewCfxClient(nodeUrl),
 	}
 }
 
-func (w *worker) Sync(ctx context.Context, wg *sync.WaitGroup, epochFrom, epochTo, stepN uint64) {
+func (w *worker) Sync(ctx context.Context, wg *sync.WaitGroup, epochFrom, epochTo uint64, batchSize, stepN int) {
+	batchSize = max(1, batchSize)
 	defer wg.Done()
 
 	etLogger := logutil.NewErrorTolerantLogger(logutil.DefaultETConfig)
@@ -38,12 +43,15 @@ func (w *worker) Sync(ctx context.Context, wg *sync.WaitGroup, epochFrom, epochT
 		case <-ctx.Done():
 			return
 		default:
-			epochData, err := w.fetchEpoch(eno)
+			targetEpoch := min(epochTo, eno+uint64(batchSize)-1)
+			epochDatas, err := w.fetchEpochs(eno, targetEpoch)
 			etLogger.Log(
 				logrus.WithFields(logrus.Fields{
-					"epochNo":    eno,
+					"fromEpoch":  eno,
+					"toEpoch":    targetEpoch,
+					"batchSize":  batchSize,
 					"workerName": w.name,
-				}), err, "Catch-up worker failed to fetch epoch",
+				}), err, "Catch-up worker failed to fetch epochs",
 			)
 
 			if err != nil {
@@ -54,8 +62,8 @@ func (w *worker) Sync(ctx context.Context, wg *sync.WaitGroup, epochFrom, epochT
 			select {
 			case <-ctx.Done():
 				return
-			case w.resultChan <- epochData:
-				eno += stepN
+			case w.resultChan <- epochDatas:
+				eno += uint64(stepN)
 			}
 		}
 	}
@@ -66,15 +74,102 @@ func (w *worker) Close() {
 	close(w.resultChan)
 }
 
-func (w *worker) Data() <-chan *store.EpochData {
+func (w *worker) ResultChan() <-chan []*store.EpochData {
 	return w.resultChan
 }
 
-func (w *worker) fetchEpoch(epochNo uint64) (*store.EpochData, error) {
-	epochData, err := store.QueryEpochData(w.cfx, epochNo, true)
-	if err == nil {
-		return &epochData, nil
+func (w *worker) fetchEpochs(fromEpoch, toEpoch uint64) ([]*store.EpochData, error) {
+	if fromEpoch > toEpoch {
+		return nil, errors.New("invalid epoch range")
 	}
 
-	return nil, err
+	// If all chain data is disabled, use `cfx_getLogs` to fetch event logs for faster sync.
+	// Otherwise, fetch full epoch data.
+	disabler := store.StoreConfig()
+	if disabler.IsChainBlockDisabled() && disabler.IsChainTxnDisabled() && disabler.IsChainReceiptDisabled() {
+		return queryEpochDataWithLogsOnly(w.cfx, fromEpoch, toEpoch)
+	}
+
+	epochDatas := make([]*store.EpochData, 0, toEpoch-fromEpoch+1)
+	for ; fromEpoch <= toEpoch; fromEpoch++ {
+		epochData, err := store.QueryEpochData(w.cfx, fromEpoch, true)
+		if err != nil {
+			return nil, err
+		}
+
+		epochDatas = append(epochDatas, &epochData)
+	}
+
+	return epochDatas, nil
+}
+
+// queryEpochDataWithLogsOnly retrieves epoch data for the specified epoch range using only event logs.
+// It constructs minimal epoch data, including blocks and transaction receipts, based on the retrieved logs.
+func queryEpochDataWithLogsOnly(cfx sdk.ClientOperator, fromEpoch, toEpoch uint64) (res []*store.EpochData, err error) {
+	startTime := time.Now()
+	defer metrics.Registry.Sync.CatchupEpochData("cfx").UpdateSince(startTime)
+
+	defer func() {
+		metrics.Registry.Sync.CatchupEpochDataAvailability("cfx").Mark(err == nil)
+	}()
+
+	// Retrieve all event logs within the specified epoch range
+	logs, err := store.QueryEventLogs(cfx, fromEpoch, toEpoch)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get event logs")
+	}
+
+	for epochNum := fromEpoch; epochNum <= toEpoch; epochNum++ {
+		// Initialize epoch data for the current epoch
+		epochData := &store.EpochData{
+			Number:   epochNum,
+			Receipts: make(map[types.Hash]*types.TransactionReceipt),
+		}
+
+		// Cache to store blocks fetched by their hash to avoid redundant network calls
+		blockCache := make(map[types.Hash]*types.Block)
+
+		// Process logs that belong to the current epoch
+		for i := range logs {
+			if logs[i].EpochNumber.ToInt().Uint64() != fromEpoch {
+				logs = logs[i:]
+				break
+			}
+
+			// Retrieve or fetch the block associated with the current log
+			blockHash := *logs[i].BlockHash
+			if _, ok := blockCache[blockHash]; !ok {
+				var block *types.Block
+				block, err = cfx.GetBlockByHash(blockHash)
+				if err != nil {
+					return nil, errors.WithMessagef(err, "failed to get block by hash %v", blockHash)
+				}
+
+				// Add the block to the epoch data and cache
+				epochData.Blocks = append(epochData.Blocks, block)
+				blockCache[blockHash] = block
+			}
+
+			// Retrieve or initialize the transaction receipt associated with the current log
+			txnHash := *logs[i].TransactionHash
+			txnReceipt, ok := epochData.Receipts[txnHash]
+			if !ok {
+				txnReceipt = &types.TransactionReceipt{
+					EpochNumber:     (*hexutil.Uint64)(&epochNum),
+					BlockHash:       blockHash,
+					TransactionHash: txnHash,
+				}
+
+				epochData.Receipts[txnHash] = txnReceipt
+			}
+
+			// Append the current log to the transaction receipt's logs
+			txnReceipt.Logs = append(txnReceipt.Logs, logs[i])
+		}
+
+		// Append the constructed epoch data to the result list
+		res = append(res, epochData)
+	}
+
+	return res, nil
 }

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -148,8 +148,16 @@ func (*SyncMetrics) QueryEpochData(space string) metrics.Timer {
 	return metricUtil.GetOrRegisterTimer("infura/sync/%v/fullnode", space)
 }
 
+func (*SyncMetrics) CatchupEpochData(space string) metrics.Timer {
+	return metricUtil.GetOrRegisterTimer("infura/catchup/%v/fullnode", space)
+}
+
 func (*SyncMetrics) QueryEpochDataAvailability(space string) metricUtil.Percentage {
 	return metricUtil.GetOrRegisterTimeWindowPercentageDefault(0, "infura/sync/%v/fullnode/availability", space)
+}
+
+func (*SyncMetrics) CatchupEpochDataAvailability(space string) metricUtil.Percentage {
+	return metricUtil.GetOrRegisterTimeWindowPercentageDefault(0, "infura/catchup/%v/fullnode/availability", space)
 }
 
 // Store metrics


### PR DESCRIPTION
- Batch epochs for synchronization per worker to improve efficiency
- Use `cfx_getLogs` to retrieve event logs, then assemble minimal epoch data for persistence

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/248)
<!-- Reviewable:end -->
