### PR TITLE
Add cache hit metrics and `eth_call` to client middleware

### DIFF
--- a/rpc/handler/eth_state.go
+++ b/rpc/handler/eth_state.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/Conflux-Chain/confura/node"
 	"github.com/Conflux-Chain/confura/util/metrics"
-	"github.com/Conflux-Chain/confura/util/rpc"
-	"github.com/Conflux-Chain/confura/util/rpc/cache"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/openweb3/web3go/types"
 )
@@ -106,8 +104,7 @@ func (h *EthStateHandler) Call(
 	blockNum *types.BlockNumberOrHash,
 ) ([]byte, error) {
 	result, err, usefs := h.doRequest(ctx, w3c, func(w3c *node.Web3goClient) (interface{}, error) {
-		nodeName := rpc.Url2NodeName(w3c.URL)
-		return cache.EthDefault.Call(nodeName, w3c.Client, callRequest, blockNum)
+		return w3c.Eth.Call(callRequest, blockNum)
 	})
 
 	metrics.Registry.RPC.Percentage("eth_call", "fullState").Mark(usefs)

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -19,6 +19,7 @@ type Metrics struct {
 	Store         StoreMetrics
 	Nodes         NodeManagerMetrics
 	VirtualFilter VirtualFilterMetrics
+	Client        ClientMetrics
 }
 
 // RPC metrics
@@ -223,4 +224,12 @@ func (*VirtualFilterMetrics) QueryFilterChanges(space, node, store string) metri
 func (*VirtualFilterMetrics) StoreQueryPercentage(space string, node, store string) metricUtil.Percentage {
 	metricName := fmt.Sprintf("infura/virtualFilter/%v/percentage/query/%v/filterChanges/%v", space, node, store)
 	return metricUtil.GetOrRegisterTimeWindowPercentageDefault(0, metricName)
+}
+
+// Client metrics
+
+type ClientMetrics struct{}
+
+func (*ClientMetrics) CacheHit(method string) metricUtil.Percentage {
+	return metricUtil.GetOrRegisterTimeWindowPercentageDefault(0, "infura/client/cache/hit/%v", method)
 }

--- a/util/rpc/cache/cache_cfx.go
+++ b/util/rpc/cache/cache_cfx.go
@@ -26,26 +26,26 @@ func NewCfx() *CfxCache {
 	}
 }
 
-func (cache *CfxCache) GetGasPrice(cfx sdk.ClientOperator) (*hexutil.Big, error) {
-	val, err := cache.priceCache.getOrUpdate(func() (interface{}, error) {
+func (cache *CfxCache) GetGasPrice(cfx sdk.ClientOperator) (*hexutil.Big, bool, error) {
+	val, loaded, err := cache.priceCache.getOrUpdate(func() (interface{}, error) {
 		return cfx.GetGasPrice()
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return val.(*hexutil.Big), nil
+	return val.(*hexutil.Big), loaded, nil
 }
 
-func (cache *CfxCache) GetClientVersion(cfx sdk.ClientOperator) (string, error) {
-	val, err := cache.versionCache.getOrUpdate(func() (interface{}, error) {
+func (cache *CfxCache) GetClientVersion(cfx sdk.ClientOperator) (string, bool, error) {
+	val, loaded, err := cache.versionCache.getOrUpdate(func() (interface{}, error) {
 		return cfx.GetClientVersion()
 	})
 
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return val.(string), nil
+	return val.(string), loaded, nil
 }

--- a/util/rpc/cache/expiry_cache_test.go
+++ b/util/rpc/cache/expiry_cache_test.go
@@ -37,7 +37,7 @@ func TestExpiryCacheGetOrUpdateWithError(t *testing.T) {
 
 	fooErr := errors.New("foo error")
 
-	val, err := cache.getOrUpdate(func() (interface{}, error) {
+	val, _, err := cache.getOrUpdate(func() (interface{}, error) {
 		return "data", fooErr
 	})
 
@@ -49,23 +49,26 @@ func TestExpiryCacheGetOrUpdate(t *testing.T) {
 	cache := newExpiryCache(time.Minute)
 
 	// cache data
-	val, err := cache.getOrUpdate(func() (interface{}, error) {
+	val, cached, err := cache.getOrUpdate(func() (interface{}, error) {
 		return "data", nil
 	})
 	assert.Equal(t, "data", val.(string))
 	assert.Nil(t, err)
+	assert.False(t, cached)
 
 	// get cached data
-	val, err = cache.getOrUpdate(func() (interface{}, error) {
+	val, cached, err = cache.getOrUpdate(func() (interface{}, error) {
 		return "data - 2", nil
 	})
 	assert.Equal(t, "data", val.(string))
 	assert.Nil(t, err)
+	assert.True(t, cached)
 
 	// timeout and get new cached data
-	val, err = cache.getOrUpdateAt(time.Now().Add(time.Minute+time.Nanosecond), func() (interface{}, error) {
+	val, cached, err = cache.getOrUpdateAt(time.Now().Add(time.Minute+time.Nanosecond), func() (interface{}, error) {
 		return "data - 2", nil
 	})
 	assert.Equal(t, "data - 2", val.(string))
 	assert.Nil(t, err)
+	assert.False(t, cached)
 }

--- a/util/rpc/cache/status.go
+++ b/util/rpc/cache/status.go
@@ -20,62 +20,64 @@ func NewStatusCache() *StatusCache {
 	}
 }
 
-func (c *StatusCache) GetStatus(nodeName string, cfx sdk.ClientOperator) (types.Status, error) {
-	val, err := c.inner.getOrUpdate(nodeName, func() (interface{}, error) {
+func (c *StatusCache) GetStatus(nodeName string, cfx sdk.ClientOperator) (types.Status, bool, error) {
+	val, loaded, err := c.inner.getOrUpdate(nodeName, func() (interface{}, error) {
 		return cfx.GetStatus()
 	})
 
 	if err != nil {
-		return types.Status{}, err
+		return types.Status{}, false, err
 	}
 
-	return val.(types.Status), nil
+	return val.(types.Status), loaded, nil
 }
 
-func (c *StatusCache) GetEpochNumber(nodeName string, cfx sdk.ClientOperator, epoch *types.Epoch) (*hexutil.Big, error) {
+func (c *StatusCache) GetEpochNumber(nodeName string, cfx sdk.ClientOperator, epoch *types.Epoch) (*hexutil.Big, bool, error) {
 	if types.EpochEarliest.Equals(epoch) {
-		return types.NewBigInt(0), nil
+		return types.NewBigInt(0), true, nil
 	}
 
-	status, err := c.GetStatus(nodeName, cfx)
+	status, loaded, err := c.GetStatus(nodeName, cfx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// latest mined by default
 	if epoch == nil {
-		return types.NewBigInt(uint64(status.EpochNumber)), nil
+		return types.NewBigInt(uint64(status.EpochNumber)), loaded, nil
 	}
 
 	// epoch number
 	if num, ok := epoch.ToInt(); ok {
 		if num.Uint64() <= uint64(status.EpochNumber) {
-			return types.NewBigIntByRaw(num), nil
+			return types.NewBigIntByRaw(num), loaded, nil
 		}
 
-		return cfx.GetEpochNumber(epoch)
+		epochNun, err := cfx.GetEpochNumber(epoch)
+		return epochNun, false, err
 	}
 
 	// default epoch tags
 	switch {
 	case types.EpochLatestCheckpoint.Equals(epoch):
-		return types.NewBigInt(uint64(status.LatestCheckpoint)), nil
+		return types.NewBigInt(uint64(status.LatestCheckpoint)), loaded, nil
 	case types.EpochLatestFinalized.Equals(epoch):
-		return types.NewBigInt(uint64(status.LatestFinalized)), nil
+		return types.NewBigInt(uint64(status.LatestFinalized)), loaded, nil
 	case types.EpochLatestConfirmed.Equals(epoch):
-		return types.NewBigInt(uint64(status.LatestConfirmed)), nil
+		return types.NewBigInt(uint64(status.LatestConfirmed)), loaded, nil
 	case types.EpochLatestState.Equals(epoch):
-		return types.NewBigInt(uint64(status.LatestState)), nil
+		return types.NewBigInt(uint64(status.LatestState)), loaded, nil
 	}
 
-	return cfx.GetEpochNumber(epoch)
+	epochNun, err := cfx.GetEpochNumber(epoch)
+	return epochNun, false, err
 }
 
-func (c *StatusCache) GetBestBlockHash(nodeName string, cfx sdk.ClientOperator) (types.Hash, error) {
-	status, err := c.GetStatus(nodeName, cfx)
+func (c *StatusCache) GetBestBlockHash(nodeName string, cfx sdk.ClientOperator) (types.Hash, bool, error) {
+	status, loaded, err := c.GetStatus(nodeName, cfx)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
-	return status.BestHash, nil
+	return status.BestHash, loaded, nil
 }


### PR DESCRIPTION
- Integrate `eth_call` handling in the client cache middleware
- Add metrics to track and monitor the cache hit ratio