### PR TITLE
Grammar and Spelling Improvements

### DIFF
--- a/util/blockchain.go
+++ b/util/blockchain.go
@@ -132,7 +132,7 @@ func NormalizeEthBlockNumber(
 		return nil, errors.WithMessagef(err, "failed to get block (%v)", blockText)
 	}
 
-	// !!! eth rpc may return nil for `pending` and `earlist` block number
+	// !!! eth rpc may return nil for `pending` and `earliest` block number
 	if block == nil {
 		blockText, _ := blockNum.MarshalText()
 		return nil, errors.Errorf("unknown block number (%v)", string(blockText))

--- a/util/rpc/rpcstack.go
+++ b/util/rpc/rpcstack.go
@@ -18,7 +18,7 @@ func newHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string) http.
 	handler = newVHostHandler(vhosts, handler)
 
 	// Due to potential memory leak (https://github.com/gin-contrib/gzip/issues/26) under
-	// high throughtout requests, we disable Gzip compressing for more memory efficiency.
+	// high throughput requests, we disable Gzip compressing for more memory efficiency.
 	// handler = newGzipHandler(handler)
 
 	return handler


### PR DESCRIPTION
## Changes Made

### File: blockchain.go
- Changed `earlist` to `earliest`
Reason: Fixed misspelling of the word "earliest" which is the correct spelling when referring to the first block in blockchain terminology.

### File: rpc/rpcstack.go  
- Changed `throughtout` to `throughput`
Reason: Corrected the spelling of "throughput" which is the proper technical term referring to the rate of successful data transfer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/253)
<!-- Reviewable:end -->
