### PR TITLE
Return lazy loaded JSON object for `eth_blockNumber`

### DIFF
--- a/util/rpc/lazy_json.go
+++ b/util/rpc/lazy_json.go
@@ -1,0 +1,62 @@
+package rpc
+
+import (
+	"encoding/json"
+	"sync/atomic"
+)
+
+// LazyJSON is a struct that holds a lazily-loaded JSON object. It reduces redundant
+// JSON marshalling and unmarshalling to improve performance by caching the JSON byte slice.
+type LazyJSON[T any] struct {
+	// cachedBytes holds the cached JSON byte slice after the first marshalling.
+	cachedBytes json.RawMessage
+	// value stores the original object, using atomic for thread-safety.
+	value atomic.Value
+}
+
+// NewLazyJSON creates a new LazyJSON instance. It accepts an initial value that will be stored lazily.
+func NewLazyJSON[T any](initialValue T) *LazyJSON[T] {
+	lazyJSON := &LazyJSON[T]{}
+	lazyJSON.value.Store(initialValue)
+	return lazyJSON
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+// It marshals the object only once and then caches the result for future use.
+func (l *LazyJSON[T]) MarshalJSON() ([]byte, error) {
+	// If cachedBytes is already set, return it directly
+	if l.cachedBytes != nil {
+		return l.cachedBytes, nil
+	}
+	// Otherwise, marshal the original value
+	rawData, err := json.Marshal(l.value.Load().(T))
+	if err != nil {
+		return nil, err
+	}
+	// Cache the marshalled JSON bytes
+	l.cachedBytes = rawData
+	return rawData, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// It unmarshals the JSON data and stores it as the original value.
+func (l *LazyJSON[T]) UnmarshalJSON(data []byte) error {
+	var decodedValue T
+	if v := l.value.Load(); v != nil {
+		decodedValue = v.(T)
+	}
+	if err := json.Unmarshal(data, &decodedValue); err != nil {
+		return err
+	}
+	// Store the decoded value atomically
+	l.value.Store(decodedValue)
+	// Cache the raw JSON bytes
+	l.cachedBytes = data
+	return nil
+}
+
+// GetOriginal returns the original object stored in the LazyJSON.
+func (l *LazyJSON[T]) GetOriginal() (T, bool) {
+	v, ok := l.value.Load().(T)
+	return v, ok
+}

--- a/util/rpc/lazy_json_test.go
+++ b/util/rpc/lazy_json_test.go
@@ -1,0 +1,55 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLazyJSONMarshalJSON tests the MarshalJSON method of LazyJSON.
+func TestLazyJSONMarshalJSON(t *testing.T) {
+	// Create an initial object with some data
+	obj := NewLazyJSON(map[string]string{"name": "John", "age": "30"})
+
+	// First call to MarshalJSON should serialize the object and cache the result
+	data, err := obj.MarshalJSON()
+	assert.NoError(t, err) // Check for no error
+
+	// Ensure the serialized data is valid JSON
+	var result map[string]string
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err) // Check for valid JSON
+
+	// Ensure cachedBytes is set after the first call
+	assert.NotNil(t, obj.cachedBytes, "expected cachedBytes to be set after first MarshalJSON call")
+
+	// Second call to MarshalJSON should return cached data
+	data2, err := obj.MarshalJSON()
+	assert.NoError(t, err) // Check for no error
+
+	// Ensure the second call returns the cached data (no re-serialization)
+	assert.Equal(t, data, data2, "expected cached data to be reused")
+}
+
+// TestLazyJSONUnmarshalJSON tests the UnmarshalJSON method of LazyJSON.
+func TestLazyJSONUnmarshalJSON(t *testing.T) {
+	// Initialize JSON data
+	data := []byte(`{"name": "Alice", "age": "25"}`)
+
+	// Create a new LazyJSON object with an empty initial value
+	obj := NewLazyJSON(map[string]string{})
+
+	// Call UnmarshalJSON to deserialize the data
+	err := obj.UnmarshalJSON(data)
+	assert.NoError(t, err) // Check for no error
+
+	// Ensure the object is correctly unmarshalled
+	original, ok := obj.GetOriginal()
+	assert.True(t, ok, "expected original object to be set")
+	assert.Equal(t, "Alice", original["name"], "expected 'name' to be 'Alice'")
+	assert.Equal(t, "25", original["age"], "expected 'age' to be '25'")
+
+	// Ensure the cachedBytes hold the same raw JSON data
+	assert.Equal(t, string(data), string(obj.cachedBytes), "expected cachedBytes to be the same as the input data")
+}


### PR DESCRIPTION
to reduce redundant JSON marshalling and unmarshalling to improve performance