### PR TITLE
Maximize transaction batch size for catch-up sync

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -229,6 +229,7 @@ eth:
 #     connMaxLifeTime: 3m
 #     maxOpenConns: 10
 #     maxIdleConns: 10
+#     createBatchSize: 500
 #     # Whether to use event log partitions hashed by contract address
 #     addressIndexedLogEnabled: true
 #     # Number of partitions for address indexed event log table, valid only if above option enabled
@@ -256,6 +257,7 @@ eth:
 #     connMaxLifeTime: 3m
 #     maxOpenConns: 10
 #     maxIdleConns: 10
+#     createBatchSize: 500
 #     addressIndexedLogEnabled: true
 #     addressIndexedLogPartitions: 100
 #     maxBnRangedArchiveLogPartitions: 5

--- a/store/mysql/config.go
+++ b/store/mysql/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ConnMaxLifetime time.Duration `default:"3m"`
 	MaxOpenConns    int           `default:"10"`
 	MaxIdleConns    int           `default:"10"`
+	CreateBatchSize int           `default:"500"`
 
 	AddressIndexedLogEnabled    bool   `default:"true"`
 	AddressIndexedLogPartitions uint32 `default:"100"`
@@ -158,7 +159,8 @@ func (config *Config) mustNewDB(database string) *gorm.DB {
 	}
 
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
-		Logger: gLogger,
+		Logger:          gLogger,
+		CreateBatchSize: config.CreateBatchSize,
 	})
 
 	if err != nil {

--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -74,6 +74,15 @@ func mustNewStore(db *gorm.DB, config *Config, option StoreOption) *MysqlStore {
 	}
 }
 
+func (ms *MysqlStore) DeepCopy(sess *gorm.Session) *MysqlStore {
+	conf := *ms.config
+	if sess.CreateBatchSize != conf.CreateBatchSize {
+		conf.CreateBatchSize = sess.CreateBatchSize
+	}
+	newDb := ms.baseStore.db.Session(sess)
+	return mustNewStore(newDb, &conf, StoreOption{Disabler: ms.disabler})
+}
+
 func (ms *MysqlStore) Push(data *store.EpochData) error {
 	return ms.Pushn([]*store.EpochData{data})
 }

--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -74,12 +74,9 @@ func mustNewStore(db *gorm.DB, config *Config, option StoreOption) *MysqlStore {
 	}
 }
 
-func (ms *MysqlStore) DeepCopy(sess *gorm.Session) *MysqlStore {
+func (ms *MysqlStore) DeepCopy() *MysqlStore {
 	conf := *ms.config
-	if sess.CreateBatchSize != conf.CreateBatchSize {
-		conf.CreateBatchSize = sess.CreateBatchSize
-	}
-	newDb := ms.baseStore.db.Session(sess)
+	newDb := ms.baseStore.db.Session(&gorm.Session{NewDB: true})
 	return mustNewStore(newDb, &conf, StoreOption{Disabler: ms.disabler})
 }
 
@@ -364,6 +361,12 @@ func (ms *MysqlStore) GetLogs(ctx context.Context, storeFilter store.LogFilter) 
 // Prune prune data from db store.
 func (ms *MysqlStore) Prune() {
 	go ms.pruner.schedulePrune(ms.config)
+}
+
+// SetCreateBatchSize sets the batch size for inserting data into tables in the database.
+func (ms *MysqlStore) SetCreateBatchSize(size int) {
+	ms.config.CreateBatchSize = size
+	ms.DB().CreateBatchSize = size
 }
 
 // newSuggestedFilterResultSetTooLargeError returns an error indicating that the filter result set is too large.

--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -74,7 +74,14 @@ func mustNewStore(db *gorm.DB, config *Config, option StoreOption) *MysqlStore {
 	}
 }
 
-func (ms *MysqlStore) DeepCopy() *MysqlStore {
+// Copy creates a new store by copying the underlying gorm db instance.
+//
+// This method is useful when you want to create a new store that is
+// independent of the current store, but still shares the same underlying
+// database connection.
+//
+// The returned store will also have the same disabler as the current store.
+func (ms *MysqlStore) Copy() *MysqlStore {
 	conf := *ms.config
 	newDb := ms.baseStore.db.Session(&gorm.Session{NewDB: true})
 	return mustNewStore(newDb, &conf, StoreOption{Disabler: ms.disabler})

--- a/store/mysql/store_block.go
+++ b/store/mysql/store_block.go
@@ -10,10 +10,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const (
-	defaultBatchSizeBlockInsert = 500
-)
-
 type block struct {
 	ID          uint64
 	Epoch       uint64 `gorm:"not null;index"`
@@ -164,7 +160,7 @@ func (bs *blockStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData) error {
 		return nil
 	}
 
-	return dbTx.CreateInBatches(blocks, defaultBatchSizeBlockInsert).Error
+	return dbTx.Create(blocks).Error
 }
 
 // Remove remove blocks of specific epoch range from db store.

--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -114,7 +114,7 @@ func (ls *logStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData, logPartitio
 	}
 
 	tblName := ls.getPartitionedTableName(&ls.model, logPartition.Index)
-	err = dbTx.Table(tblName).CreateInBatches(logs, defaultBatchSizeLogInsert).Error
+	err = dbTx.Table(tblName).Create(logs).Error
 	if err != nil {
 		return err
 	}

--- a/store/mysql/store_log_addr.go
+++ b/store/mysql/store_log_addr.go
@@ -11,8 +11,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const defaultBatchSizeLogInsert = 500
-
 // Address indexed logs are used to filter event logs by contract address and optional block number.
 // Generally, most contracts have limited event logs and need not to specify the epoch/block range filter.
 // For some active contracts, e.g. USDT, that have many event logs, could store in separate tables.
@@ -128,7 +126,7 @@ func (ls *AddressIndexedLogStore) AddAddressIndexedLogs(dbTx *gorm.DB, data *sto
 	// Insert address indexed logs into different partitions.
 	for partition, logs := range partition2Logs {
 		tableName := ls.getPartitionedTableName(&ls.model, partition)
-		if err := dbTx.Table(tableName).CreateInBatches(&logs, defaultBatchSizeLogInsert).Error; err != nil {
+		if err := dbTx.Table(tableName).Create(&logs).Error; err != nil {
 			return err
 		}
 	}

--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -166,7 +166,7 @@ func (vfls *VirtualFilterLogStore) Append(fid string, logs []VirtualFilterLog, p
 
 		// batch insert new event logs
 		tblName := vfls.getPartitionedTableName(ftabler, partition.Index)
-		err = tx.Table(tblName).CreateInBatches(logs, defaultBatchSizeLogInsert).Error
+		err = tx.Table(tblName).Create(logs).Error
 		if err != nil {
 			return err
 		}

--- a/store/mysql/store_tx.go
+++ b/store/mysql/store_tx.go
@@ -11,8 +11,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const defaultBatchSizeTxnInsert = 500
-
 type transaction struct {
 	ID                uint64
 	Epoch             uint64 `gorm:"not null;index"`
@@ -190,7 +188,7 @@ func (ts *txStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData, skipTx, skip
 		return nil
 	}
 
-	return dbTx.CreateInBatches(txns, defaultBatchSizeTxnInsert).Error
+	return dbTx.Create(txns).Error
 }
 
 // Remove remove transactions of specific epoch range from db store.

--- a/sync/catchup/boost.go
+++ b/sync/catchup/boost.go
@@ -547,9 +547,8 @@ func (s *boostSyncer) fetchAndPersistResults(ctx context.Context, start, end uin
 			forcePersist = true
 		}
 
-		// Batch insert into db if `forcePersist` is true or enough db rows collected, also use total db rows here to
-		// check if we need to persist to restrict memory usage.
-		if forcePersist || state.totalDbRows >= s.maxDbRows || state.insertDbRows >= s.minBatchDbRows {
+		// Batch insert into db if `forcePersist` is true or enough db rows collected.
+		if forcePersist || state.insertDbRows >= s.minBatchDbRows {
 			if err := s.persist(ctx, &state, bmarker); err != nil {
 				return err
 			}

--- a/sync/catchup/syncer.go
+++ b/sync/catchup/syncer.go
@@ -150,7 +150,9 @@ func newSyncer(
 	cOpts = append(cOpts, opts...)
 
 	// Deep copy db store to maximize txn batch size for catch-up sync
-	newDbs := dbs.DeepCopy(&gorm.Session{CreateBatchSize: 0, NewDB: true})
+	newDbs := dbs.DeepCopy()
+	newDbs.SetCreateBatchSize(0)
+
 	syncer := &Syncer{
 		elm:            elm,
 		db:             newDbs,


### PR DESCRIPTION
- Enable configurable `createBatchSize` parameter for GORM DB.
- Remove the batch size limitation for the catch-up syncer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/289)
<!-- Reviewable:end -->
