### PR TITLE
Fix Measurement Name and Error Handling in Virtual Filter Log

### DIFF
--- a/grafana/Node-Management.json
+++ b/grafana/Node-Management.json
@@ -340,7 +340,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "/^$nodeAvailabilty$/",
+          "measurement": "/^$nodeAvailability$/",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -660,7 +660,7 @@
         "includeAll": true,
         "label": "",
         "multi": true,
-        "name": "nodeAvailabilty",
+        "name": "nodeAvailability",
         "options": [],
         "query": "show measurements",
         "refresh": 1,

--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -174,7 +174,7 @@ func (vfls *VirtualFilterLogStore) Append(fid string, logs []VirtualFilterLog, p
 		// expand partition block number range
 		err := vfls.expandPartitioBnRange(tx, fentity, partition.Index, bnMin, bnMax)
 		if err != nil {
-			return errors.WithMessage(err, "failed to expand partiton bn range")
+			return errors.WithMessage(err, "failed to expand partition bn range")
 		}
 
 		// update partition data count
@@ -234,7 +234,7 @@ func (vfls *VirtualFilterLogStore) GetLogs(
 }
 
 // GC garbage collects archive partitions exceeded the max archive partition limit
-// starting from the oldest partiton.
+// starting from the oldest partition.
 func (vfls *VirtualFilterLogStore) GC(fid string) error {
 	fentity, ftabler := vfls.filterEntity(fid), vfls.filterTabler(fid)
 	_, err := vfls.pruneArchivePartitions(fentity, ftabler, maxArchiveVirtualFilterLogPartitions)


### PR DESCRIPTION
**This pull request includes the following changes:**
1. Measurement Name Update:
Changed the measurement name from `nodeAvailability` to `nodeAvailability` to ensure consistency in naming conventions.
2. Error Handling Improvement:
Enhanced error handling in the `expandPartitionRange` function to provide clearer error messages when partition expansion fails.

These changes aim to improve the clarity and reliability of the code, ensuring better maintainability and easier debugging in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/290)
<!-- Reviewable:end -->
