### PR TITLE
Optimize event log storage for boost catchup and perf

### DIFF
--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -177,10 +177,8 @@ func (ms *MysqlStore) PushnWithFinalizer(dataSlice []*store.EpochData, finalizer
 				}
 
 				// save address indexed event logs
-				for _, data := range dataSlice {
-					if err := ms.ails.AddAddressIndexedLogs(dbTx, data, bigContractIds); err != nil {
-						return errors.WithMessage(err, "failed to save address indexed event logs")
-					}
+				if err := ms.ails.Add(dbTx, dataSlice, bigContractIds); err != nil {
+					return errors.WithMessage(err, "failed to save address indexed event logs")
 				}
 
 				// save contract specified event logs

--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -130,7 +130,7 @@ func (ls *logStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData, logPartitio
 
 // Popn pops event logs until the specific epoch from db store.
 func (ls *logStore) Popn(dbTx *gorm.DB, epochUntil uint64) error {
-	bn, ok, err := ls.ebms.BlockRange(epochUntil)
+	e2bmap, ok, err := ls.ebms.CeilBlockMapping(epochUntil)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get block mapping for epoch %v", epochUntil)
 	}
@@ -140,7 +140,7 @@ func (ls *logStore) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 	}
 
 	// update block range for log partition router
-	partitions, existed, err := ls.shrinkBnRange(dbTx, bnPartitionedLogEntity, bn.From)
+	partitions, existed, err := ls.shrinkBnRange(dbTx, bnPartitionedLogEntity, e2bmap.BnMin)
 	if err != nil {
 		return errors.WithMessage(err, "failed to shrink partition bn range")
 	}
@@ -153,7 +153,7 @@ func (ls *logStore) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 		partition := partitions[i]
 		tblName := ls.getPartitionedTableName(&log{}, partition.Index)
 
-		res := dbTx.Table(tblName).Where("bn >= ?", bn.From).Delete(log{})
+		res := dbTx.Table(tblName).Where("bn >= ?", e2bmap.BnMin).Delete(log{})
 		if res.Error != nil {
 			return res.Error
 		}

--- a/store/mysql/store_log_addr.go
+++ b/store/mysql/store_log_addr.go
@@ -37,7 +37,6 @@ type AddressIndexedLogStore struct {
 	partitionedStore
 	db         *gorm.DB
 	cs         *ContractStore
-	ebms       *epochBlockMapStore
 	model      AddressIndexedLog
 	partitions uint32
 }
@@ -116,7 +115,7 @@ func (ls *AddressIndexedLogStore) convertToPartitionedLogs(
 	return partition2Logs, contract2LogCount, nil
 }
 
-// Add adds event logs of specified epoch (with that of big contract ignored) into different partitioned tables.
+// Add inserts event logs from a batch of epochs into partitioned tables, while ignoring logs from big contracts.
 func (ls *AddressIndexedLogStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData, bigContractIds map[uint64]bool) error {
 	var (
 		allContract2LogCount      = make(map[uint64]int)

--- a/store/mysql/store_log_addr.go
+++ b/store/mysql/store_log_addr.go
@@ -37,6 +37,7 @@ type AddressIndexedLogStore struct {
 	partitionedStore
 	db         *gorm.DB
 	cs         *ContractStore
+	ebms       *epochBlockMapStore
 	model      AddressIndexedLog
 	partitions uint32
 }
@@ -115,25 +116,54 @@ func (ls *AddressIndexedLogStore) convertToPartitionedLogs(
 	return partition2Logs, contract2LogCount, nil
 }
 
-// AddAddressIndexedLogs adds event logs of specified epoch (with that of big contract ignored) into different partitioned tables.
-func (ls *AddressIndexedLogStore) AddAddressIndexedLogs(dbTx *gorm.DB, data *store.EpochData, bigContractIds map[uint64]bool) error {
-	// divide event logs into different partitions by address
-	partition2Logs, contract2LogCount, err := ls.convertToPartitionedLogs(data, bigContractIds)
-	if err != nil {
-		return err
+// Add adds event logs of specified epoch (with that of big contract ignored) into different partitioned tables.
+func (ls *AddressIndexedLogStore) Add(dbTx *gorm.DB, dataSlice []*store.EpochData, bigContractIds map[uint64]bool) error {
+	var (
+		allContract2LogCount      = make(map[uint64]int)
+		allContract2UpdatedEpochs = make(map[uint64]uint64)
+		allPartition2Logs         = make(map[uint32][]*AddressIndexedLog)
+	)
+
+	// Merge all event logs of different epochs partitioned by contract address together for later bulk insert for performance.
+	//
+	// `allPartition2Logs` is used to store all event logs of different epochs partitioned by contract address.
+	// `allContract2LogCount` is used to store the total count of event logs for each contract.
+	// `allContract2UpdatedEpochs` is used to store the updated epoch for each contract.
+	for _, data := range dataSlice {
+		// Divides event logs into different partitions by address.
+		partition2Logs, contract2LogCount, err := ls.convertToPartitionedLogs(data, bigContractIds)
+		if err != nil {
+			return errors.WithMessage(err, "failed to convert to partitioned logs")
+		}
+
+		// Merge all event logs of different epochs partitioned by contract address into `allPartition2Logs`
+		for partition, logs := range partition2Logs {
+			allPartition2Logs[partition] = append(allPartition2Logs[partition], logs...)
+		}
+
+		// Merge all count of event logs for each contract into `allContract2LogCount`
+		for cid, logCount := range contract2LogCount {
+			allContract2LogCount[cid] += logCount
+		}
+
+		// Update the updated epoch for each contract into `allContract2UpdatedEpochs`
+		for cid := range contract2LogCount {
+			allContract2UpdatedEpochs[cid] = data.Number
+		}
 	}
 
 	// Insert address indexed logs into different partitions.
-	for partition, logs := range partition2Logs {
+	for partition, logs := range allPartition2Logs {
 		tableName := ls.getPartitionedTableName(&ls.model, partition)
 		if err := dbTx.Table(tableName).Create(&logs).Error; err != nil {
 			return err
 		}
 	}
 
-	for cid, logCount := range contract2LogCount {
+	for cid, logCount := range allContract2LogCount {
 		// Update contract statistics (log count and lastest updated epoch).
-		if err := ls.cs.UpdateContractStats(dbTx, cid, logCount, data.Number); err != nil {
+		latestUpdatedEpoch := allContract2UpdatedEpochs[cid]
+		if err := ls.cs.UpdateContractStats(dbTx, cid, logCount, latestUpdatedEpoch); err != nil {
 			return errors.WithMessage(err, "failed to update contract statistics")
 		}
 	}
@@ -150,6 +180,10 @@ func (ls *AddressIndexedLogStore) DeleteAddressIndexedLogs(dbTx *gorm.DB, epochF
 		return errors.WithMessage(err, "failed to get updated contracts since start epoch")
 	}
 
+	if len(contracts) == 0 {
+		return nil
+	}
+
 	// Delete logs for all possible contracts in batches.
 	for _, contract := range contracts {
 		partition := ls.getPartitionByAddress(contract.Address)
@@ -162,6 +196,8 @@ func (ls *AddressIndexedLogStore) DeleteAddressIndexedLogs(dbTx *gorm.DB, epochF
 		}
 
 		// Update contract statistics (log count and lastest updated epoch).
+		// A rough estimation of the number of logs deleted from the contract, not accounting for other contracts in the same partition
+		// since the accuracy is not critical and it happens rarely.
 		if err := ls.cs.UpdateContractStats(dbTx, contract.ID, int(-res.RowsAffected), epochFrom); err != nil {
 			return errors.WithMessage(err, "failed to update contract statistics")
 		}


### PR DESCRIPTION
- Handle potential gaps in epoch-to-block mappings introduced by boost catchup sync
- Implements batch insertion for address-indexed event logs for better performance

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/293)
<!-- Reviewable:end -->
