### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -144,7 +143,7 @@ func (vfls *VirtualFilterLogStore) Append(fid string, logs []VirtualFilterLog, p
 			blockHashes = append(blockHashes, bh)
 		}
 
-		bnMin, bnMax = util.MinUint64(bn, bnMin), util.MaxUint64(bn, bnMax)
+		bnMin, bnMax = min(bn, bnMin), max(bn, bnMax)
 	}
 
 	fentity, ftabler := vfls.filterEntity(fid), vfls.filterTabler(fid)

--- a/store/redis/models.go
+++ b/store/redis/models.go
@@ -223,7 +223,7 @@ func loadEpochRange(ctx context.Context, rc redis.Cmdable, dt store.EpochDataTyp
 		}
 	}
 
-	epochRanges[0] = util.MinUint64(epochRanges[0], epochRanges[1])
+	epochRanges[0] = min(epochRanges[0], epochRanges[1])
 	if epochRanges[0] == citypes.EpochNumberNil { // both epoch number are uninitialized
 		return 0, 0, store.ErrNotFound
 	}

--- a/sync/epoch_window.go
+++ b/sync/epoch_window.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"github.com/Conflux-Chain/confura/types"
-	"github.com/Conflux-Chain/confura/util"
 )
 
 // epochWindow maintains a continuous epoch window with a fixed size capacity.
@@ -27,7 +26,7 @@ func (win *epochWindow) reset(epochFrom, epochTo uint64) {
 // Expand the epoch window from a smaller epoch number.
 func (win *epochWindow) expandFrom(epochNo uint64) {
 	if win.isSet() {
-		win.epochFrom = util.MinUint64(win.epochFrom, epochNo)
+		win.epochFrom = min(win.epochFrom, epochNo)
 	} else {
 		win.reset(epochNo, epochNo)
 	}
@@ -36,7 +35,7 @@ func (win *epochWindow) expandFrom(epochNo uint64) {
 // Expand the epoch window to a bigger epoch number.
 func (win *epochWindow) expandTo(epochNo uint64) {
 	if win.isSet() {
-		win.epochTo = util.MaxUint64(win.epochTo, epochNo)
+		win.epochTo = max(win.epochTo, epochNo)
 	} else {
 		win.reset(epochNo, epochNo)
 	}
@@ -75,7 +74,7 @@ func (win *epochWindow) peekShrinkFrom(specSize uint32) (syncFrom uint64, syncSi
 		return 0, 0
 	}
 
-	return win.epochFrom, util.MinUint32(win.size(), specSize)
+	return win.epochFrom, min(win.size(), specSize)
 }
 
 // Shrink no more than the specified size of epoch(s) from the epoch window.
@@ -84,7 +83,7 @@ func (win *epochWindow) shrinkFrom(specSize uint32) (uint64, uint32) {
 		return 0, 0
 	}
 
-	syncFrom, syncSize := win.epochFrom, util.MinUint32(win.size(), specSize)
+	syncFrom, syncSize := win.epochFrom, min(win.size(), specSize)
 	win.epochFrom += uint64(syncSize)
 
 	return syncFrom, syncSize

--- a/sync/epoch_window_test.go
+++ b/sync/epoch_window_test.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"testing"
 
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -94,7 +93,7 @@ func TestEpochWindowShrinkFrom(t *testing.T) {
 	ew.reset(23892, 24503)
 	sf, ss = ew.peekShrinkFrom(5000)
 	assert.Equal(t, ew.epochFrom, sf)
-	assert.Equal(t, util.MinUint32(ew.size(), 5000), ss)
+	assert.Equal(t, min(ew.size(), 5000), ss)
 
 	sf2, ss2 := ew.shrinkFrom(5000)
 	assert.Equal(t, sf, sf2)

--- a/sync/prune.go
+++ b/sync/prune.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Conflux-Chain/confura/store"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/Conflux-Chain/go-conflux-util/viper"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -147,7 +146,7 @@ func (pruner *Pruner) doPruneEpochData(dt store.EpochDataType) error {
 
 	// Calculate max epoch number until to which epoch data to be dequeued
 	epochUntil := minEpoch + pruner.pruneConfig.MaxPruneEpochs - 1
-	epochUntil = util.MinUint64(epochUntil, maxEpoch)
+	epochUntil = min(epochUntil, maxEpoch)
 
 	logrus.WithField("epochUntil", epochUntil).Infof("%v dequeue epoch %v data", pruner.name, dt.Name())
 

--- a/sync/sync_check.go
+++ b/sync/sync_check.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/store/mysql"
 	citypes "github.com/Conflux-Chain/confura/types"
-	"github.com/Conflux-Chain/confura/util"
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
 	"github.com/Conflux-Chain/go-conflux-sdk/types"
 	"github.com/pkg/errors"
@@ -89,7 +88,7 @@ func ensureEpochRangeNotRerverted(
 		winEnd = winStart - 1      // decrease winEnd to the left one of winStart
 		winStart = epochRange.From // set winStart to the first epoch of the epoch range
 		if winEnd >= winSize {     // if winEnd can cover winSize, calculate the winStart
-			winStart = util.MaxUint64(winEnd-winSize+1, epochRange.From) // also make sure winStart be within the epoch range
+			winStart = max(winEnd-winSize+1, epochRange.From) // also make sure winStart be within the epoch range
 		}
 	}
 

--- a/sync/sync_db.go
+++ b/sync/sync_db.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Conflux-Chain/confura/sync/election"
 	"github.com/Conflux-Chain/confura/sync/monitor"
 	citypes "github.com/Conflux-Chain/confura/types"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
 	"github.com/Conflux-Chain/go-conflux-sdk/types"
@@ -355,7 +354,7 @@ func (syncer *DatabaseSyncer) doTicker(ctx context.Context, ticker *time.Timer) 
 }
 
 func (syncer *DatabaseSyncer) nextEpochTo(maxEpochTo uint64) (uint64, uint64) {
-	epochTo := util.MinUint64(syncer.epochFrom+syncer.maxSyncEpochs-1, maxEpochTo)
+	epochTo := min(syncer.epochFrom+syncer.maxSyncEpochs-1, maxEpochTo)
 
 	if epochTo < syncer.epochFrom {
 		return epochTo, 0

--- a/sync/sync_eth.go
+++ b/sync/sync_eth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Conflux-Chain/confura/sync/catchup"
 	"github.com/Conflux-Chain/confura/sync/election"
 	"github.com/Conflux-Chain/confura/sync/monitor"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	cfxtypes "github.com/Conflux-Chain/go-conflux-sdk/types"
 	"github.com/Conflux-Chain/go-conflux-util/dlock"
@@ -181,7 +180,7 @@ func (syncer *EthSyncer) doTicker(ctx context.Context, ticker *time.Timer) error
 }
 
 func (syncer *EthSyncer) nextBlockTo(maxBlockTo uint64) (uint64, uint64) {
-	toBlock := util.MinUint64(syncer.fromBlock+syncer.maxSyncBlocks-1, maxBlockTo)
+	toBlock := min(syncer.fromBlock+syncer.maxSyncBlocks-1, maxBlockTo)
 	syncSize := toBlock - syncer.fromBlock + 1
 	return toBlock, syncSize
 }

--- a/util/gasstation/estimater.go
+++ b/util/gasstation/estimater.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/Conflux-Chain/confura/util"
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
 	"github.com/Conflux-Chain/go-conflux-sdk/types"
 	"github.com/montanaflynn/stats"
@@ -257,7 +256,7 @@ func (e *GasPriceEstimater) collectStats() (bool, error) {
 	}
 
 	// collect tx sample statistics
-	startEpoch := util.MaxUint64(
+	startEpoch := max(
 		e.estimateWin.startEpoch, e.estimateWin.endEpoch-batchStatsEpochs+1,
 	)
 

--- a/util/math.go
+++ b/util/math.go
@@ -5,43 +5,6 @@ import (
 	"time"
 )
 
-func MaxUint64(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func MinUint64(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func MinInt(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-func MaxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func MinUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
 func RandUint64(limit uint64) uint64 {
 	if limit == 0 {
 		return 0

--- a/util/relay/relay.go
+++ b/util/relay/relay.go
@@ -71,7 +71,7 @@ func (relayer *txnRelayer) Relay(signedTx hexutil.Bytes) bool {
 
 // run starts concurrency worker(s) asynchronously
 func (relayer *txnRelayer) run(process func()) {
-	concurrency := util.MaxInt(relayer.Concurrency, 1)
+	concurrency := max(relayer.Concurrency, 1)
 	for i := 0; i < concurrency; i++ {
 		go process()
 	}

--- a/virtualfilter/cfx_filter.go
+++ b/virtualfilter/cfx_filter.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/store/mysql"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	rpcutil "github.com/Conflux-Chain/confura/util/rpc"
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
@@ -122,7 +121,7 @@ func (f *cfxLogFilter) fetch() (filterChanges, error) {
 	for _, fe := range pchanges.epochs {
 		if !fe.reorged() && len(fe.logs) == 0 { // filter epochs missing of event logs
 			missingBlockhashes = append(missingBlockhashes, fe.blockHash.String())
-			bnMin, bnMax = util.MinUint64(fe.epochNum, bnMin), util.MaxUint64(fe.epochNum, bnMax)
+			bnMin, bnMax = min(fe.epochNum, bnMin), max(fe.epochNum, bnMax)
 		}
 	}
 

--- a/virtualfilter/eth_filter.go
+++ b/virtualfilter/eth_filter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Conflux-Chain/confura/node"
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/store/mysql"
-	"github.com/Conflux-Chain/confura/util"
 	"github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/openweb3/go-rpc-provider"
 	"github.com/openweb3/web3go/types"
@@ -121,7 +120,7 @@ func (f *ethLogFilter) fetch() (filterChanges, error) {
 	for _, fb := range pchanges.blocks {
 		if len(fb.logs) == 0 { // filter blocks missing of event logs
 			missingBlockhashes = append(missingBlockhashes, fb.blockHash.String())
-			bnMin, bnMax = util.MinUint64(fb.blockNum, bnMin), util.MaxUint64(fb.blockNum, bnMax)
+			bnMin, bnMax = min(fb.blockNum, bnMin), max(fb.blockNum, bnMax)
 		}
 	}
 

--- a/virtualfilter/validity_test.go
+++ b/virtualfilter/validity_test.go
@@ -178,7 +178,7 @@ func TestCfxFilterDataValidity(t *testing.T) {
 			if len(fepoch.logs) == 0 { // pruned?
 				valStartEpochNum, valEndEpochNum = uint64(math.MaxUint64), uint64(0)
 			} else {
-				valStartEpochNum = util.MinUint64(valStartEpochNum, fepoch.epochNum)
+				valStartEpochNum = min(valStartEpochNum, fepoch.epochNum)
 				valEndEpochNum = fepoch.epochNum
 			}
 
@@ -320,7 +320,7 @@ func TestEthFilterDataValidity(t *testing.T) {
 			if len(fblock.logs) == 0 { // pruned?
 				valStartBlockNum, valEndBlockNum = uint64(math.MaxUint64), uint64(0)
 			} else {
-				valStartBlockNum = util.MinUint64(valStartBlockNum, fblock.blockNum)
+				valStartBlockNum = min(valStartBlockNum, fblock.blockNum)
 				valEndBlockNum = fblock.blockNum
 			}
 


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/299)
<!-- Reviewable:end -->
