### PR TITLE
fix: conflicting AllowMethods and DisallowMethods logic in AllowList

### DIFF
--- a/util/acl/allowlist.go
+++ b/util/acl/allowlist.go
@@ -1,7 +1,7 @@
 package acl
 
 const (
-	// pre-defined default allowlist name
+	// Pre-defined default allowlist name
 	DefaultAllowList = "default"
 )
 
@@ -26,9 +26,37 @@ type AllowList struct {
 	Origins []string
 }
 
+// NewAllowList creates a new AllowList instance with the given ID and name.
 func NewAllowList(id uint32, name string) *AllowList {
 	return &AllowList{
 		ID:   id,
 		Name: name,
 	}
+}
+
+// IsMethodAllowed checks if a given method is allowed according to the allowlist rules.
+// Priority:
+// 1. If the method is listed in DisallowMethods — it is rejected.
+// 2. If AllowMethods is not empty — only listed methods are accepted.
+// 3. If AllowMethods is empty — all methods are accepted (unless disallowed above).
+func (al *AllowList) IsMethodAllowed(method string) bool {
+	if contains(al.DisallowMethods, method) {
+		return false
+	}
+
+	if len(al.AllowMethods) > 0 {
+		return contains(al.AllowMethods, method)
+	}
+
+	return true
+}
+
+// contains checks if a slice contains a specific string.
+func contains(list []string, item string) bool {
+	for _, v := range list {
+		if v == item {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
I noticed a potential logical conflict in `AllowList` where a method could be both allowed and disallowed at the same time. I’ve adjusted the logic to give priority to `DisallowMethods`, which makes sense — if something is explicitly disallowed, it should not be permitted under any condition.

Now:
- `DisallowMethods` takes precedence over everything.
- `AllowMethods` only filters if it’s non-empty.
- If `AllowMethods` is empty, all methods are allowed (unless disallowed explicitly).

This makes the behavior clear, consistent, and safe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/303)
<!-- Reviewable:end -->
