### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/util/blockchain.go
+++ b/util/blockchain.go
@@ -3,6 +3,7 @@ package util
 import (
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
@@ -196,12 +197,7 @@ func GetEthHardforkBlockNumber(chainId uint64) web3goTypes.BlockNumber {
 // MatchEthLogTopics checks if the eSpace event log matches with the given topics condition
 func MatchEthLogTopics(log *web3goTypes.Log, topics [][]common.Hash) bool {
 	find := func(t common.Hash, topics []common.Hash) bool {
-		for _, topic := range topics {
-			if t == topic {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(topics, t)
 	}
 
 	for i := range topics {
@@ -219,13 +215,7 @@ func MatchEthLogTopics(log *web3goTypes.Log, topics [][]common.Hash) bool {
 
 // IncludeEthLogAddrs checks if the eSpace event logs include any of the given addresses
 func IncludeEthLogAddrs(log *web3goTypes.Log, addresses []common.Address) bool {
-	for _, addr := range addresses {
-		if log.Address == addr {
-			return true
-		}
-	}
-
-	return len(addresses) == 0
+	return len(addresses) == 0 || slices.Contains(addresses, log.Address)
 }
 
 // IncludeCfxLogAddrs checks if the core space event logs include any of the given addresses
@@ -242,12 +232,7 @@ func IncludeCfxLogAddrs(log *types.Log, addresses []cfxaddress.Address) bool {
 // MatchCfxLogTopics checks if the core space event log matches with the given topics condition
 func MatchCfxLogTopics(log *types.Log, topics [][]types.Hash) bool {
 	find := func(t types.Hash, topics []types.Hash) bool {
-		for _, topic := range topics {
-			if t == topic {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(topics, t)
 	}
 
 	for i := range topics {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/310)
<!-- Reviewable:end -->
