### PR TITLE
Improve configuration and logging

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -360,11 +360,11 @@ node:
   #   # Node manager RPC endpoint for `NodeRpcRouter`
   #   nodeRpcUrl: http://127.0.0.1:22530
   #   # Node manager gRPC endpoint for `NodeRpcRouter`
-  #   nodeRpcUrlProto: http://127.0.0.1:22531
+  #   nodeRpcUrlProto: 127.0.0.1:22531
   #   # EVM space node manager RPC endpoint for `NodeRpcRouter`
   #   ethNodeRpcUrl: http://127.0.0.1:28530
   #   # EVM space node manager gRPC endpoint for `NodeRpcRouter`
-  #   ethNodeRpcUrlProto: http://127.0.0.1:28531
+  #   ethNodeRpcUrlProto: 127.0.0.1:28531
   #   # Failover fullnode configuration
   #   chainedFailover:
   #     # Failover fullnode if group `cfxhttp` is capsized
@@ -483,7 +483,7 @@ node:
 #     callCacheExpiration: 1s
 #     callCacheSize: 128
 #     # Remote data cache gRPC service endpoint (refer to https://github.com/Conflux-Chain/confura-data-cache)
-#     #dataCacheEndpoint: http://127.0.0.1:48545
+#     #dataCacheRpcUrlProto: 127.0.0.1:48545
 
 #   # ETH receipt retrieval configuration
 #   ethReceiptRetrieval:

--- a/node/router.go
+++ b/node/router.go
@@ -181,7 +181,7 @@ func (r *RedisRouter) Route(group Group, key []byte) string {
 	}
 
 	if err != nil {
-		logrus.WithError(err).WithField("key", redisKey).Error("Failed to route key from redis")
+		logrus.WithField("key", redisKey).WithError(err).Info("Failed to route key from redis")
 		return ""
 	}
 
@@ -202,7 +202,7 @@ func NewNodeRpcRouter(client *rpc.Client) *NodeRpcRouter {
 func (r *NodeRpcRouter) Route(group Group, key []byte) string {
 	var result string
 	if err := r.client.Call(&result, "node_route", group, hexutil.Bytes(key)); err != nil {
-		logrus.WithError(err).Debug("Failed to route key from node RPC")
+		logrus.WithField("key", string(key)).WithError(err).Info("Failed to route key from node RPC")
 		return ""
 	}
 
@@ -243,7 +243,7 @@ func (r *NodeGRPCRouter) Route(group Group, key []byte) string {
 
 	resp, err := r.client.Route(ctx, &req)
 	if err != nil {
-		logrus.WithError(err).Debug("Failed to route key from node gRPC")
+		logrus.WithField("key", string(key)).WithError(err).Info("Failed to route key from node gRPC")
 		return ""
 	}
 

--- a/util/rpc/cached_client_eth.go
+++ b/util/rpc/cached_client_eth.go
@@ -27,7 +27,7 @@ func newCacheBlockTypeConverter(nodeName string, eth *client.RpcEthClient) cache
 }
 
 func MustNewEthDataCacheClientFromViper() cacheRpc.Interface {
-	url := viper.GetString("requestControl.ethCache.dataCacheEndpoint")
+	url := viper.GetString("requestControl.ethCache.dataCacheRpcUrlProto")
 	if len(url) == 0 {
 		return nil
 	}


### PR DESCRIPTION
- gRPC endpoint shouldn't start with protocol prefix (eg. http://) for config
- Info logging when routers fail to route

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/318)
<!-- Reviewable:end -->
