### PR TITLE
Support state/block overrides in eSpace call & gas estimation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Conflux-Chain/confura-data-cache v0.0.0-20250701033646-9e89dbf0f1c1
 	github.com/Conflux-Chain/go-conflux-sdk v1.5.11-0.20240913040447-d33c1c8903b2
 	github.com/Conflux-Chain/go-conflux-util v0.5.0
-	github.com/Conflux-Chain/web3pay-service v1.0.0
+	github.com/Conflux-Chain/web3pay-service v1.0.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/buraksezer/consistent v0.9.0
 	github.com/cespare/xxhash v1.1.0
@@ -20,7 +20,7 @@ require (
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/montanaflynn/stats v0.6.6
 	github.com/openweb3/go-rpc-provider v0.3.5
-	github.com/openweb3/web3go v0.3.1-0.20250814081736-d2e9f1eefc15
+	github.com/openweb3/web3go v0.3.1-0.20250818071020-a79f6aa44340
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/Conflux-Chain/go-conflux-sdk v1.5.11-0.20240913040447-d33c1c8903b2 h1
 github.com/Conflux-Chain/go-conflux-sdk v1.5.11-0.20240913040447-d33c1c8903b2/go.mod h1:nJHYufKOuTqtZkVA1c/peRU9rsx5Bt5QhIW+q/Bg1q0=
 github.com/Conflux-Chain/go-conflux-util v0.5.0 h1:Nz5epLjZWXHmap6OniFLUgfOYevMM/y+SVyGyx4/ARA=
 github.com/Conflux-Chain/go-conflux-util v0.5.0/go.mod h1:29nLPJH9GO4z6jaY6YRuK03zsLwpANmwUh4tPuWPtWw=
-github.com/Conflux-Chain/web3pay-service v1.0.0 h1:/TLMiesyBcR+ncLSts2SaOecskkLn/8cZ7yk8/oNtyc=
-github.com/Conflux-Chain/web3pay-service v1.0.0/go.mod h1:+tVIr3r0Fk8T5tZhABtvAzVEB8g4PitrRzvpIz+gDXI=
+github.com/Conflux-Chain/web3pay-service v1.0.1 h1:jMXEsZGDervBCokopyUnuY8tLD+ZumCp/x21qBtH2N0=
+github.com/Conflux-Chain/web3pay-service v1.0.1/go.mod h1:K14HzyhDQ7OD0Es3/D4Ta1UEP0JNX+Zo3YTGrQg0lbw=
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DmitriyVTitov/size v1.5.0 h1:/PzqxYrOyOUX1BXj6J9OuVRVGe+66VL4D9FlUaW515g=
@@ -456,8 +456,9 @@ github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -482,8 +483,8 @@ github.com/openweb3/go-rpc-provider v0.3.5 h1:KEKtJiEtCV9dhVkpGe+mf0CpNmMDpSZPbZ
 github.com/openweb3/go-rpc-provider v0.3.5/go.mod h1:eXd8viZzDcuvHKhl0Y14x92pGo4uzSB3Y0My5KOd+NM=
 github.com/openweb3/go-sdk-common v0.0.0-20240627072707-f78f0155ab34 h1:qLelmviLGRleOB6A8ssljatvs6K6n1BMd3PNeozNq/E=
 github.com/openweb3/go-sdk-common v0.0.0-20240627072707-f78f0155ab34/go.mod h1:YMfzbYeq1G7s6nRjcFAgYSA/Uqy5+Aa1UvL0Rbnc290=
-github.com/openweb3/web3go v0.3.1-0.20250814081736-d2e9f1eefc15 h1:LsYlsZCKCq3NSo+AZvK7t+I80j6Ri4q4f5dTVyiJ3fw=
-github.com/openweb3/web3go v0.3.1-0.20250814081736-d2e9f1eefc15/go.mod h1:N9G0bo4m3D4005g8EOPNDDx2Ex0lPMhMNJk23mZ5WMs=
+github.com/openweb3/web3go v0.3.1-0.20250818071020-a79f6aa44340 h1:baadF4kXb3vT7G0JYvnC2of03ztnWKywNrVFNV7/tD8=
+github.com/openweb3/web3go v0.3.1-0.20250818071020-a79f6aa44340/go.mod h1:N9G0bo4m3D4005g8EOPNDDx2Ex0lPMhMNJk23mZ5WMs=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/rpc/cfxbridge/cfx_api.go
+++ b/rpc/cfxbridge/cfx_api.go
@@ -198,7 +198,7 @@ func (api *CfxAPI) Call(ctx context.Context, request EthCallRequest, bn *EthBloc
 	if err != nil {
 		return nil, errors.WithMessage(err, "invalid call request")
 	}
-	return api.w3c.WithContext(ctx).Eth.Call(callMsg, bn.ToArg())
+	return api.w3c.WithContext(ctx).Eth.Call(callMsg, bn.ToArg(), nil, nil)
 }
 
 func (api *CfxAPI) GetLogs(ctx context.Context, filter EthLogFilter) ([]types.Log, error) {
@@ -230,7 +230,7 @@ func (api *CfxAPI) EstimateGasAndCollateral(ctx context.Context, request EthCall
 		return types.Estimate{}, errors.WithMessage(err, "invalid call request")
 	}
 
-	gasLimit, err := api.w3c.WithContext(ctx).Eth.EstimateGas(callMsg, bn.ToArg())
+	gasLimit, err := api.w3c.WithContext(ctx).Eth.EstimateGas(callMsg, bn.ToArg(), nil, nil)
 	if err != nil {
 		return types.Estimate{}, err
 	}

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -250,11 +250,15 @@ func (api *ethAPI) SubmitTransaction(ctx context.Context, signedTx hexutil.Bytes
 
 // Call executes a new message call immediately without creating a transaction on the block chain.
 func (api *ethAPI) Call(
-	ctx context.Context, request web3Types.CallRequest, blockNumOrHash *web3Types.BlockNumberOrHash,
+	ctx context.Context,
+	request web3Types.CallRequest,
+	blockNumOrHash *web3Types.BlockNumberOrHash,
+	overrides *web3Types.StateOverride,
+	blockOverrides *web3Types.BlockOverrides,
 ) (hexutil.Bytes, error) {
 	w3c := GetEthClientFromContext(ctx)
 	api.inputBlockMetric.Update2(blockNumOrHash, "eth_call", w3c.Eth)
-	return api.stateHandler.Call(ctx, w3c, request, blockNumOrHash)
+	return api.stateHandler.Call(ctx, w3c, request, blockNumOrHash, overrides, blockOverrides)
 }
 
 // EstimateGas generates and returns an estimate of how much gas is necessary to allow the transaction
@@ -262,11 +266,15 @@ func (api *ethAPI) Call(
 // significantly more than the amount of gas actually used by the transaction, for a variety of reasons
 // including EVM mechanics and node performance or miner policy.
 func (api *ethAPI) EstimateGas(
-	ctx context.Context, request web3Types.CallRequest, blockNumOrHash *web3Types.BlockNumberOrHash,
+	ctx context.Context,
+	request web3Types.CallRequest,
+	blockNumOrHash *web3Types.BlockNumberOrHash,
+	overrides *web3Types.StateOverride,
+	blockOverrides *web3Types.BlockOverrides,
 ) (*hexutil.Big, error) {
 	w3c := GetEthClientFromContext(ctx)
 	api.inputBlockMetric.Update2(blockNumOrHash, "eth_estimateGas", w3c.Eth)
-	gas, err := api.stateHandler.EstimateGas(ctx, w3c, request, blockNumOrHash)
+	gas, err := api.stateHandler.EstimateGas(ctx, w3c, request, blockNumOrHash, overrides, blockOverrides)
 	return (*hexutil.Big)(gas), err
 }
 

--- a/rpc/handler/eth_state.go
+++ b/rpc/handler/eth_state.go
@@ -103,9 +103,11 @@ func (h *EthStateHandler) Call(
 	w3c *node.Web3goClient,
 	callRequest types.CallRequest,
 	blockNum *types.BlockNumberOrHash,
+	overrides *types.StateOverride,
+	blockOverrides *types.BlockOverrides,
 ) ([]byte, error) {
 	result, err, usefs := h.doRequest(ctx, w3c, func(w3c *node.Web3goClient) (interface{}, error) {
-		return w3c.Eth.Call(callRequest, blockNum)
+		return w3c.Eth.Call(callRequest, blockNum, overrides, blockOverrides)
 	})
 
 	metrics.Registry.RPC.Percentage("eth_call", "fullState").Mark(usefs)
@@ -122,9 +124,11 @@ func (h *EthStateHandler) EstimateGas(
 	w3c *node.Web3goClient,
 	callRequest types.CallRequest,
 	blockNum *types.BlockNumberOrHash,
+	overrides *types.StateOverride,
+	blockOverrides *types.BlockOverrides,
 ) (*big.Int, error) {
 	est, err, usefs := h.doRequest(ctx, w3c, func(w3c *node.Web3goClient) (interface{}, error) {
-		return w3c.Eth.EstimateGas(callRequest, blockNum)
+		return w3c.Eth.EstimateGas(callRequest, blockNum, overrides, blockOverrides)
 	})
 
 	metrics.Registry.RPC.Percentage("eth_estimateGas", "fullState").Mark(usefs)

--- a/util/rpc/cached_client_eth.go
+++ b/util/rpc/cached_client_eth.go
@@ -209,8 +209,15 @@ func (c cachedRpcEthClient) BlockNumber() (*big.Int, error) {
 	})
 }
 
-func (c cachedRpcEthClient) Call(callRequest web3Types.CallRequest, blockNum *web3Types.BlockNumberOrHash) ([]byte, error) {
-	res, loaded, err := lruCache.EthDefault.Call(c.nodeName, c.RpcEthClient, callRequest, blockNum)
+func (c cachedRpcEthClient) Call(
+	callRequest web3Types.CallRequest,
+	blockNum *web3Types.BlockNumberOrHash,
+	overrides *web3Types.StateOverride,
+	blockOverrides *web3Types.BlockOverrides,
+) ([]byte, error) {
+	res, loaded, err := lruCache.EthDefault.Call(
+		c.nodeName, c.RpcEthClient, callRequest, blockNum, overrides, blockOverrides,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensures compatibility with geth’s API by allowing state and block overrides for eSpace call and gas estimation requests.