### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/util/metrics/traffics.go
+++ b/util/metrics/traffics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"container/heap"
+	"maps"
 	"sync"
 	"time"
 
@@ -82,9 +83,7 @@ func (twTrafficSlotAggregator) Clone(v twTrafficSlotData) twTrafficSlotData {
 	}
 
 	copy := make(twTrafficSlotData, len(v))
-	for k, v := range v {
-		copy[k] = v
-	}
+	maps.Copy(copy, v)
 
 	return copy
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.