### PR TITLE
fix: correct typos in comments and error messages

### DIFF
--- a/node/client.go
+++ b/node/client.go
@@ -114,7 +114,7 @@ func (p *clientProvider[T]) populateCache(token string) (grp Group, ok bool) {
 		defer p.mu.Unlock()
 
 		// for db error, we cache an empty group for the key by which no expiry cache value existed
-		// so that db pressure can be mitigrated by reducing too many subsequential queries.
+		// so that db pressure can be mitigated by reducing too many subsequential queries.
 		if _, _, found := p.routeKeyCache.GetWithoutExp(token); !found {
 			p.routeKeyCache.Add(token, grp)
 		}

--- a/node/client.go
+++ b/node/client.go
@@ -98,7 +98,7 @@ func (p *clientProvider[T]) cacheLoad(key string) (Group, bool) {
 	}
 
 	if found && expired {
-		// extend lifespan for expired cache kv temporarliy for performance
+		// extend lifespan for expired cache kv temporarily for performance
 		p.routeKeyCache.Add(key, v.(Group))
 	}
 

--- a/rpc/cfxbridge/trace_builder.go
+++ b/rpc/cfxbridge/trace_builder.go
@@ -66,7 +66,7 @@ func (tb *TraceBuilder) pop(traceAddress []uint) error {
 		// previous trace should always exist
 		topEle := tb.stackedResults.Back()
 		if topEle == nil {
-			return fmt.Errorf("no trace adddress in stack, cur = %v", traceAddress)
+			return fmt.Errorf("no trace address in stack, cur = %v", traceAddress)
 		}
 
 		pre := topEle.Value.(stackedTraceResult)


### PR DESCRIPTION
- client.go:
  - "temporarliy" → "temporarily"
  - "mitigrated" → "mitigated"
- trace_builder.go:
  - fixed error message typo "adddress" → "address"