### PR TITLE
ix typos in messages/comments 

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -178,7 +178,7 @@ func nativeSpaceBridgeApis(config *CfxBridgeServerConfig) ([]API, error) {
 	rpc.HookMiddlewares(eth.Provider(), ethNodeURL, "eth")
 
 	var cfx *sdk.Client
-	if len(cfxNodeURL) > 0 { // optioinal
+	if len(cfxNodeURL) > 0 { // optional
 		cfx, err = rpc.NewCfxClient(cfxNodeURL)
 		if err != nil {
 			return nil, errors.WithMessage(err, "Failed to connect to cfx space")


### PR DESCRIPTION

- `rpc/cfxbridge/trace_builder.go`: correct “adddress” → “address” in error.
- `util/rpc/middlewares/recover.go`: correct “responce” → “response” in comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/346)
<!-- Reviewable:end -->
