### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"math"
+	"slices"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -148,8 +149,7 @@ func (ls *logStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 		return nil
 	}
 
-	for i := len(partitions) - 1; i >= 0; i-- {
-		partition := partitions[i]
+	for _, partition := range slices.Backward(partitions) {
 		tblName := ls.getPartitionedTableName(&log{}, partition.Index)
 
 		res := dbTx.Table(tblName).Where("bn >= ?", e2bmap.BnMin).Delete(log{})

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -328,8 +329,7 @@ func (bcls *bigContractLogStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error
 			continue
 		}
 
-		for i := len(partitions) - 1; i >= 0; i-- {
-			partition := partitions[i]
+		for _, partition := range slices.Backward(partitions) {
 			tblName := bcls.getPartitionedTableName(contractTabler, partition.Index)
 
 			res := dbTx.Table(tblName).Where("bn >= ?", e2bmap.BnMin).Delete(&contractLog{})

--- a/store/mysql/store_log_big_topic.go
+++ b/store/mysql/store_log_big_topic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -321,8 +322,7 @@ func (btls *bigTopicLogStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 			continue
 		}
 
-		for i := len(partitions) - 1; i >= 0; i-- {
-			partition := partitions[i]
+		for _, partition := range slices.Backward(partitions) {
 			tblName := btls.getPartitionedTableName(tlTabler, partition.Index)
 
 			res := dbTx.Table(tblName).Where("bn >= ?", e2bmap.BnMin).Delete(nil)

--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -154,8 +155,8 @@ func (vfls *VirtualFilterLogStore) Append(fid string, logs []VirtualFilterLog, p
 
 	return vfls.db.Transaction(func(tx *gorm.DB) error {
 		// soft delete event logs within db, whose block hashes coincides with the to be appended ones
-		for i := len(partitions) - 1; i >= 0; i-- {
-			tblName := vfls.getPartitionedTableName(ftabler, partitions[i].Index)
+		for _, v := range slices.Backward(partitions) {
+			tblName := vfls.getPartitionedTableName(ftabler, v.Index)
 
 			dbtx := tx.Table(tblName).Where("bn BETWEEN ? AND ?", bnMin, bnMax).Where("bh IN (?)", blockHashes)
 			if res := dbtx.Update("is_del", true); res.Error != nil {

--- a/util/gasstation/estimater.go
+++ b/util/gasstation/estimater.go
@@ -2,6 +2,7 @@ package gasstation
 
 import (
 	"math/big"
+	"slices"
 	"time"
 
 	sdk "github.com/Conflux-Chain/go-conflux-sdk"
@@ -158,8 +159,7 @@ func (e *GasPriceEstimater) gather() (bool, error) {
 		tx2EstimateSamples := make(map[types.Hash]*gasPriceUsedSample, len(blockHashes))
 
 		// fetch epoch block one by one
-		for i := len(blockHashes) - 1; i >= 0; i-- {
-			blkHash := blockHashes[i]
+		for i, blkHash := range slices.Backward(blockHashes) {
 
 			block, err := e.cfx.GetBlockByHash(blkHash)
 			if err != nil {

--- a/util/rpc/handlers/ip.go
+++ b/util/rpc/handlers/ip.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -75,8 +76,8 @@ func GetIPAddress(r *http.Request) string {
 		addresses := strings.Split(r.Header.Get(h), ",")
 		// march from right to left until we get a public address
 		// that will be the address right before our proxy.
-		for i := len(addresses) - 1; i >= 0; i-- {
-			ip := strings.TrimSpace(addresses[i])
+		for _, v := range slices.Backward(addresses) {
+			ip := strings.TrimSpace(v)
 			// header can contain spaces too, strip those out.
 			realIP := net.ParseIP(ip)
 			if !realIP.IsGlobalUnicast() || isPrivateSubnet(realIP) {

--- a/util/rpc/server.go
+++ b/util/rpc/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -62,9 +63,9 @@ func MustNewServer(name string, rpcs map[string]interface{}, middlewares ...hand
 		}),
 	}
 
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		httpServer.Handler = middlewares[i](httpServer.Handler)
-		wsServer.Handler = middlewares[i](wsServer.Handler)
+	for _, v := range slices.Backward(middlewares) {
+		httpServer.Handler = v(httpServer.Handler)
+		wsServer.Handler = v(wsServer.Handler)
 	}
 
 	return &Server{


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/386)
<!-- Reviewable:end -->
