### PR TITLE
acl: reject contract-scoped requests that constrain no address

### DIFF
--- a/util/acl/validator.go
+++ b/util/acl/validator.go
@@ -209,6 +209,13 @@ func (v *validatorBase) validateContractAddresses(ctx Context) error {
 		return errBadRpcParams
 	}
 
+	// A request that constrains no contract address, such as a getLogs filter with an
+	// empty address list, would match every contract and bypass the allowlist. Reject
+	// it when an allowlist is configured for this method.
+	if len(cntAddrs) == 0 {
+		return errInvalidContractAddr
+	}
+
 	for _, caddr := range cntAddrs {
 		if !v.cntAddrRules[strings.ToLower(caddr)] {
 			return errInvalidContractAddr

--- a/util/acl/validator_test.go
+++ b/util/acl/validator_test.go
@@ -1,0 +1,81 @@
+package acl
+
+import (
+	"context"
+	"testing"
+
+	cfxTypes "github.com/Conflux-Chain/go-conflux-sdk/types"
+	"github.com/Conflux-Chain/go-conflux-sdk/types/cfxaddress"
+	"github.com/ethereum/go-ethereum/common"
+	web3Types "github.com/openweb3/web3go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	allowedContractAddr    = "0x2000000000000000000000000000000000000002"
+	notAllowedContractAddr = "0x3000000000000000000000000000000000000003"
+)
+
+func ethGetLogsContext(fq web3Types.FilterQuery) Context {
+	return Context{
+		Context:   context.Background(),
+		RpcMethod: "eth_getLogs",
+		ExtractRpcParams: func() ([]interface{}, error) {
+			return []interface{}{fq}, nil
+		},
+	}
+}
+
+func cfxGetLogsContext(fq cfxTypes.LogFilter) Context {
+	return Context{
+		Context:   context.Background(),
+		RpcMethod: "cfx_getLogs",
+		ExtractRpcParams: func() ([]interface{}, error) {
+			return []interface{}{fq}, nil
+		},
+	}
+}
+
+func TestEthGetLogsAllowlist(t *testing.T) {
+	v := NewEthValidator(&AllowList{ContractAddresses: []string{allowedContractAddr}})
+
+	// A filter targeting an allowlisted contract is permitted.
+	err := v.Validate(ethGetLogsContext(web3Types.FilterQuery{
+		Addresses: []common.Address{common.HexToAddress(allowedContractAddr)},
+	}))
+	require.NoError(t, err)
+
+	// A filter targeting a non-allowlisted contract is rejected.
+	err = v.Validate(ethGetLogsContext(web3Types.FilterQuery{
+		Addresses: []common.Address{common.HexToAddress(notAllowedContractAddr)},
+	}))
+	require.ErrorIs(t, err, errInvalidContractAddr)
+
+	// A filter that constrains no contract address would match every contract, so it
+	// must not slip past the allowlist.
+	err = v.Validate(ethGetLogsContext(web3Types.FilterQuery{}))
+	require.ErrorIs(t, err, errInvalidContractAddr)
+}
+
+func TestEthGetLogsWithoutAllowlistIsUnrestricted(t *testing.T) {
+	v := NewEthValidator(&AllowList{})
+
+	err := v.Validate(ethGetLogsContext(web3Types.FilterQuery{}))
+	assert.NoError(t, err)
+}
+
+func TestCfxGetLogsAllowlist(t *testing.T) {
+	allowed := cfxaddress.MustNew(allowedContractAddr, 1)
+	v := NewCfxValidator(&AllowList{ContractAddresses: []string{allowed.MustGetBase32Address()}})
+
+	// A filter targeting an allowlisted contract is permitted.
+	err := v.Validate(cfxGetLogsContext(cfxTypes.LogFilter{
+		Address: []cfxaddress.Address{allowed},
+	}))
+	require.NoError(t, err)
+
+	// An address-less filter must not bypass the allowlist.
+	err = v.Validate(cfxGetLogsContext(cfxTypes.LogFilter{}))
+	require.ErrorIs(t, err, errInvalidContractAddr)
+}


### PR DESCRIPTION
## Summary

A getLogs filter with an empty address list matched every contract, so a caller restricted to specific contracts through a contract allowlist could read logs outside it by omitting the address field. This treats an empty parsed address set as a denial when an allowlist is configured for the method.

The change is scoped to the methods that take a contract-address parameter and only affects callers that have a contract allowlist configured. Requests that carry an address, and callers without an allowlist, are unaffected. It closes the gap for both eth_getLogs and cfx_getLogs.

## Behavior change

Any key with a contract allowlist can no longer issue an address-less getLogs. Such a request is now rejected instead of matching all contracts.

## Tests

Added unit tests covering:

- eth: allowlisted address permitted, non-allowlisted rejected, address-less rejected
- eth: unrestricted when no allowlist is configured
- cfx: allowlisted permitted, address-less rejected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/401)
<!-- Reviewable:end -->
