### PR TITLE
pubsub: avoid blocking the delegate lock on a full subscriber error channel

### DIFF
--- a/rpc/pubsub.go
+++ b/rpc/pubsub.go
@@ -99,7 +99,13 @@ func (sub *delegateSubscription) deliver(result interface{}) bool {
 	case 1: // sub.channel<-
 		return true
 	case 2: // never blocking for subscription queue overflow
-		sub.err <- rpc.ErrSubscriptionQueueOverflow
+		// The error channel is buffered for a single terminal error. If one is already
+		// pending the subscriber is being torn down anyway, so drop the duplicate rather
+		// than block here while the delegate read lock is held.
+		select {
+		case sub.err <- rpc.ErrSubscriptionQueueOverflow:
+		default:
+		}
 		return false
 	}
 
@@ -201,7 +207,14 @@ func (dctx *delegateContext) cancel(err error) {
 
 	dctx.delegateSubs.Range(func(key, value interface{}) bool {
 		dsub := value.(*delegateSubscription)
-		dsub.err <- err
+		// Non-blocking send: the error channel is buffered for a single terminal error,
+		// and this runs while the delegate write lock is held. If an error is already
+		// pending the subscriber will observe it and tear down, so a full channel here
+		// must not stall the whole delegate.
+		select {
+		case dsub.err <- err:
+		default:
+		}
 
 		dctx.delegateSubs.Delete(key)
 		return true

--- a/rpc/pubsub_overflow_test.go
+++ b/rpc/pubsub_overflow_test.go
@@ -1,0 +1,75 @@
+package rpc
+
+import (
+	"testing"
+	"time"
+
+	rpc "github.com/openweb3/go-rpc-provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newStalledDelegateSub returns a delegate context holding one subscription whose
+// downstream channel has no reader, so every deliver overflows onto the (buffered,
+// size 1) error channel.
+func newStalledDelegateSub(t *testing.T) (*delegateContext, *delegateSubscription) {
+	t.Helper()
+
+	dctx := newDelegateContext()
+	ch := make(chan int) // unbuffered, no reader
+	sub := newDelegateSubscription(dctx, rpc.NewID(), ch)
+	dctx.delegateSubs.Store(sub.subId, sub)
+
+	return dctx, sub
+}
+
+func completesWithin(d time.Duration, fn func()) bool {
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// notify must not block on a subscriber whose error channel is already full. The
+// delegate is shared across all subscribers, and notify holds the read lock, so a
+// blocking send here would stall delivery for everyone.
+func TestNotifyDoesNotBlockOnFullErrorChannel(t *testing.T) {
+	dctx, sub := newStalledDelegateSub(t)
+
+	// First notify overflows and buffers exactly one error.
+	dctx.notify(1)
+	require.Len(t, sub.err, 1)
+
+	// A second notify must complete even though the error channel is now full.
+	require.True(t, completesWithin(2*time.Second, func() { dctx.notify(2) }),
+		"notify blocked while a subscriber's error channel was full")
+
+	// The first overflow error is still delivered to the subscriber.
+	select {
+	case err := <-sub.err:
+		assert.Equal(t, rpc.ErrSubscriptionQueueOverflow, err)
+	default:
+		t.Fatal("expected the first overflow error to be buffered for the subscriber")
+	}
+}
+
+// cancel must not block on a subscriber whose error channel is already full. It holds
+// the write lock, so a blocking send here would freeze the whole delegate.
+func TestCancelDoesNotBlockOnFullErrorChannel(t *testing.T) {
+	dctx, sub := newStalledDelegateSub(t)
+
+	// Pre-fill the error channel via an overflowing notify.
+	dctx.notify(1)
+	require.Len(t, sub.err, 1)
+
+	require.True(t, completesWithin(2*time.Second, func() { dctx.cancel(nil) }),
+		"cancel blocked while a subscriber's error channel was full")
+}


### PR DESCRIPTION
## Summary

Two delegate error sends ran while a delegate lock was held, and blocked when a subscriber's buffered error channel was already full.

In `deliver`, the subscription queue overflow error was sent under the delegate read lock held by `notify`. A single slow subscriber whose error channel was full would stall `notify`, stopping delivery for every subscriber sharing the delegate.

In `cancel`, the terminal error was sent to each subscriber under the delegate write lock. If any subscriber already had a buffered error, the send blocked while holding the write lock, freezing the whole delegate.

Both sends are now non-blocking. The error channel is buffered for a single terminal error, so once one is pending the subscriber tears down regardless and the duplicate can be dropped. The existing deregister-under-lock ordering is unchanged, so no send on a closed channel is introduced.

## Tests

Added regression tests that drive `notify` and `cancel` with a subscriber whose error channel is full and assert neither blocks, and that the first overflow error is still delivered to the subscriber.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/402)
<!-- Reviewable:end -->
