### PR TITLE
store: fix log partition boundaries and migration ranges

### DIFF
--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -309,21 +309,36 @@ func (handler *CfxLogsApiHandler) splitLogFilter(
 		return nil, filter, nil
 	}
 
+	firstE2bMap, ok, err := handler.ms.CeilBlockMapping(0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !ok {
+		return nil, filter, nil
+	}
+
 	if len(filter.BlockHashes) > 0 {
-		return handler.splitLogFilterByBlockHashes(cfx, filter, maxEpoch)
+		return handler.splitLogFilterByBlockHashes(
+			cfx, filter, firstE2bMap.Epoch, maxEpoch, firstE2bMap.BnMin,
+		)
 	}
 
 	if filter.FromBlock != nil && filter.ToBlock != nil {
-		return handler.splitLogFilterByBlockRange(cfx, filter, e2bMap.BnMax)
+		return handler.splitLogFilterByBlockRange(
+			cfx, filter, firstE2bMap.BnMin, e2bMap.BnMax,
+		)
 	}
 
-	return handler.splitLogFilterByEpochRange(cfx, filter, maxEpoch, e2bMap.BnMax)
+	return handler.splitLogFilterByEpochRange(
+		cfx, filter, firstE2bMap.Epoch, maxEpoch, e2bMap.BnMax,
+	)
 }
 
 func (handler *CfxLogsApiHandler) splitLogFilterByBlockHashes(
 	cfx sdk.ClientOperator,
 	filter *types.LogFilter,
-	maxEpoch uint64,
+	minEpoch, maxEpoch, minBlock uint64,
 ) ([]store.LogFilter, *types.LogFilter, error) {
 	var dbBlockNumbers []int
 	var fnBlockHashes []types.Hash
@@ -347,7 +362,13 @@ func (handler *CfxLogsApiHandler) splitLogFilterByBlockHashes(
 			return nil, nil, fmt.Errorf("block with hash %v is not executed yet", hash)
 		}
 
-		bn := int(block.BlockNumber.ToInt().Uint64())
+		blockNumber := block.BlockNumber.ToInt().Uint64()
+		epoch := block.EpochNumber.ToInt().Uint64()
+		if epoch <= maxEpoch && (epoch < minEpoch || blockNumber < minBlock) {
+			return nil, nil, store.ErrAlreadyPruned
+		}
+
+		bn := int(blockNumber)
 
 		// dedupe
 		if _, ok := blockNumToHash[bn]; ok {
@@ -356,7 +377,7 @@ func (handler *CfxLogsApiHandler) splitLogFilterByBlockHashes(
 
 		blockNumToHash[bn] = hash
 
-		if epoch := block.EpochNumber.ToInt().Uint64(); epoch <= maxEpoch {
+		if epoch <= maxEpoch {
 			dbBlockNumbers = append(dbBlockNumbers, bn)
 		} else {
 			fnBlockHashes = append(fnBlockHashes, hash)
@@ -388,10 +409,14 @@ func (handler *CfxLogsApiHandler) splitLogFilterByBlockHashes(
 func (handler *CfxLogsApiHandler) splitLogFilterByBlockRange(
 	cfx sdk.ClientOperator,
 	filter *types.LogFilter,
-	maxBlock uint64,
+	minBlock, maxBlock uint64,
 ) ([]store.LogFilter, *types.LogFilter, error) {
-	// no data in database
 	blockFrom := filter.FromBlock.ToInt().Uint64()
+	if blockFrom < minBlock {
+		return nil, nil, store.ErrAlreadyPruned
+	}
+
+	// no data in database
 	if blockFrom > maxBlock {
 		return nil, filter, nil
 	}
@@ -421,11 +446,15 @@ func (handler *CfxLogsApiHandler) splitLogFilterByBlockRange(
 func (handler *CfxLogsApiHandler) splitLogFilterByEpochRange(
 	cfx sdk.ClientOperator,
 	filter *types.LogFilter,
-	maxEpoch, maxBlock uint64,
+	minEpoch, maxEpoch, maxBlock uint64,
 ) ([]store.LogFilter, *types.LogFilter, error) {
 	epochFrom, ok := filter.FromEpoch.ToInt()
 	if !ok {
 		return nil, filter, nil
+	}
+
+	if epochFrom.Uint64() < minEpoch {
+		return nil, nil, store.ErrAlreadyPruned
 	}
 
 	// no data in database

--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -291,47 +291,36 @@ func (handler *CfxLogsApiHandler) splitLogFilter(
 	cfx sdk.ClientOperator,
 	filter *types.LogFilter,
 ) ([]store.LogFilter, *types.LogFilter, error) {
-	maxEpoch, ok, err := handler.ms.MaxEpoch()
+	earliestMapping, ok, err := handler.ms.EarliestBlockMapping()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	if !ok {
 		return nil, filter, nil
 	}
 
-	e2bMap, ok, err := handler.ms.BlockMapping(maxEpoch)
+	latestMapping, ok, err := handler.ms.LatestBlockMapping()
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if !ok {
-		return nil, filter, nil
-	}
-
-	firstE2bMap, ok, err := handler.ms.CeilBlockMapping(0)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if !ok {
 		return nil, filter, nil
 	}
 
 	if len(filter.BlockHashes) > 0 {
 		return handler.splitLogFilterByBlockHashes(
-			cfx, filter, firstE2bMap.Epoch, maxEpoch, firstE2bMap.BnMin,
+			cfx, filter, earliestMapping.Epoch, latestMapping.Epoch, earliestMapping.BnMin,
 		)
 	}
 
 	if filter.FromBlock != nil && filter.ToBlock != nil {
 		return handler.splitLogFilterByBlockRange(
-			cfx, filter, firstE2bMap.BnMin, e2bMap.BnMax,
+			cfx, filter, earliestMapping.BnMin, latestMapping.BnMax,
 		)
 	}
 
 	return handler.splitLogFilterByEpochRange(
-		cfx, filter, firstE2bMap.Epoch, maxEpoch, e2bMap.BnMax,
+		cfx, filter, earliestMapping.Epoch, latestMapping.Epoch, latestMapping.BnMax,
 	)
 }
 

--- a/rpc/handler/eth_logs.go
+++ b/rpc/handler/eth_logs.go
@@ -199,29 +199,27 @@ func (handler *EthLogsApiHandler) splitLogFilter(
 	eth *client.RpcEthClient,
 	filter *types.FilterQuery,
 ) (*store.LogFilter, *types.FilterQuery, error) {
-	maxBlock, ok, err := handler.es.MaxEpoch()
+	earliestMapping, ok, err := handler.es.EarliestBlockMapping()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	if !ok {
 		return nil, filter, nil
 	}
 
-	firstMapping, ok, err := handler.es.CeilBlockMapping(0)
+	latestMapping, ok, err := handler.es.LatestBlockMapping()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	if !ok {
 		return nil, filter, nil
 	}
 
 	if filter.BlockHash != nil {
-		return handler.splitLogFilterByBlockHash(eth, filter, firstMapping.BnMin, maxBlock)
+		return handler.splitLogFilterByBlockHash(eth, filter, earliestMapping.BnMin, latestMapping.BnMax)
 	}
 
-	return handler.splitLogFilterByBlockRange(filter, firstMapping.BnMin, maxBlock)
+	return handler.splitLogFilterByBlockRange(filter, earliestMapping.BnMin, latestMapping.BnMax)
 }
 
 func (handler *EthLogsApiHandler) splitLogFilterByBlockHash(

--- a/rpc/handler/eth_logs.go
+++ b/rpc/handler/eth_logs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Conflux-Chain/confura/store/mysql"
 	citypes "github.com/Conflux-Chain/confura/types"
 	"github.com/Conflux-Chain/confura/util/metrics"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/openweb3/web3go/client"
 	"github.com/openweb3/web3go/types"
 	"github.com/pkg/errors"
@@ -18,6 +19,10 @@ type EthLogsApiHandler struct {
 	es *mysql.EthStore
 
 	maxSuggestAttempts int
+}
+
+type ethBlockByHashClient interface {
+	BlockByHash(blockHash common.Hash, isFull bool) (*types.Block, error)
 }
 
 func NewEthLogsApiHandler(es *mysql.EthStore, maxAttempts int) *EthLogsApiHandler {
@@ -203,16 +208,26 @@ func (handler *EthLogsApiHandler) splitLogFilter(
 		return nil, filter, nil
 	}
 
-	if filter.BlockHash != nil {
-		return handler.splitLogFilterByBlockHash(eth, filter, maxBlock)
+	firstMapping, ok, err := handler.es.CeilBlockMapping(0)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return handler.splitLogFilterByBlockRange(eth, filter, maxBlock)
+	if !ok {
+		return nil, filter, nil
+	}
+
+	if filter.BlockHash != nil {
+		return handler.splitLogFilterByBlockHash(eth, filter, firstMapping.BnMin, maxBlock)
+	}
+
+	return handler.splitLogFilterByBlockRange(filter, firstMapping.BnMin, maxBlock)
 }
 
 func (handler *EthLogsApiHandler) splitLogFilterByBlockHash(
-	eth *client.RpcEthClient,
+	eth ethBlockByHashClient,
 	filter *types.FilterQuery,
+	minBlock uint64,
 	maxBlock uint64,
 ) (*store.LogFilter, *types.FilterQuery, error) {
 	block, err := eth.BlockByHash(*filter.BlockHash, false)
@@ -225,6 +240,9 @@ func (handler *EthLogsApiHandler) splitLogFilterByBlockHash(
 	}
 
 	bn := block.Number.Uint64()
+	if bn < minBlock {
+		return nil, nil, store.ErrAlreadyPruned
+	}
 
 	if bn > maxBlock {
 		return nil, filter, nil
@@ -235,8 +253,8 @@ func (handler *EthLogsApiHandler) splitLogFilterByBlockHash(
 }
 
 func (handler *EthLogsApiHandler) splitLogFilterByBlockRange(
-	eth *client.RpcEthClient,
 	filter *types.FilterQuery,
+	minBlock uint64,
 	maxBlock uint64,
 ) (*store.LogFilter, *types.FilterQuery, error) {
 	if filter.FromBlock == nil || *filter.FromBlock < 0 {
@@ -248,6 +266,9 @@ func (handler *EthLogsApiHandler) splitLogFilterByBlockRange(
 	}
 
 	blockFrom, blockTo := uint64(*filter.FromBlock), uint64(*filter.ToBlock)
+	if blockFrom < minBlock {
+		return nil, nil, store.ErrAlreadyPruned
+	}
 
 	// no data in database
 	if blockFrom > maxBlock {

--- a/store/mysql/store_common_partition_bn.go
+++ b/store/mysql/store_common_partition_bn.go
@@ -170,100 +170,96 @@ func (bnps *bnPartitionedStore) searchPartitions(
 ) (
 	partitions []*bnPartition, uncoverings *types.RangeUint64, err error,
 ) {
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
-		defer cancel()
+	metadata := make([]*bnPartition, 0)
+	err = bnps.db.WithContext(ctx).
+		Where("entity = ?", entity).
+		Where("bn_min IS NOT NULL AND bn_max IS NOT NULL").
+		Order("pi ASC").
+		Find(&metadata).Error
+	if err != nil {
+		return nil, nil, err
 	}
 
-	readRange := func(ctx context.Context, entity string) (bnPartitionRangeSnapshot, error) {
-		bnStart, bnEnd, existed, err := bnps.bnRangeWithContext(ctx, entity)
-		return bnPartitionRangeSnapshot{start: bnStart, end: bnEnd, existed: existed}, err
-	}
-	readOverlap := func(
-		ctx context.Context, entity string, searchRange types.RangeUint64,
-	) ([]*bnPartition, error) {
-		return bnps.searchOverlapPartitionsWithContext(ctx, entity, searchRange)
-	}
-
-	return searchPartitionsUntilStable(ctx, entity, searchRange, readRange, readOverlap)
+	return searchPartitionsFromMetadata(entity, searchRange, metadata)
 }
 
-type bnPartitionRangeSnapshot struct {
-	start   uint64
-	end     uint64
-	existed bool
-}
-
-type bnPartitionRangeReader func(context.Context, string) (bnPartitionRangeSnapshot, error)
-
-type bnPartitionOverlapReader func(context.Context, string, types.RangeUint64) ([]*bnPartition, error)
-
-// searchPartitionsUntilStable makes sure the partition metadata used for routing did not change
-// while the overlapping partitions were being selected. Partition pruning advances the covered
-// range monotonically, so retrying until two consecutive range reads match prevents returning a
-// partial result selected from stale metadata.
-func searchPartitionsUntilStable(
-	ctx context.Context,
-	entity string,
-	searchRange types.RangeUint64,
-	readRange bnPartitionRangeReader,
-	readOverlap bnPartitionOverlapReader,
+// searchPartitionsFromMetadata validates one consistent metadata snapshot and routes the search
+// range entirely in memory. Valid partition metadata must be index-contiguous and its block ranges
+// must be ordered without overlaps. Gaps between block ranges are allowed because an indexed
+// contract/topic may have no logs for a span of blocks.
+func searchPartitionsFromMetadata(
+	entity string, searchRange types.RangeUint64, metadata []*bnPartition,
 ) ([]*bnPartition, *types.RangeUint64, error) {
-	for {
-		if ctx.Err() != nil {
-			return nil, nil, store.ErrGetLogsTimeout
+	if len(metadata) == 0 {
+		return nil, &searchRange, nil
+	}
+
+	for i, partition := range metadata {
+		if partition == nil || !partition.BnMin.Valid || !partition.BnMax.Valid {
+			return nil, nil, errors.Errorf(
+				"invalid bn partition metadata for entity %q at position %v", entity, i,
+			)
+		}
+		if partition.BnMin.Int64 < 0 || partition.BnMax.Int64 < 0 {
+			return nil, nil, errors.Errorf(
+				"negative bn partition metadata for entity %q partition %v",
+				entity, partition.Index,
+			)
 		}
 
-		before, err := readRange(ctx, entity)
-		if ctx.Err() != nil {
-			return nil, nil, store.ErrGetLogsTimeout
-		}
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if before.existed && searchRange.From < before.start {
-			// Pruning only advances the lower bound, so this range cannot become queryable
-			// after another metadata read and may fail without selecting overlap partitions.
-			bnPartRange := types.RangeUint64{From: before.start, To: before.end}
-			return nil, nil, errBnPartitionsPruned(searchRange, bnPartRange)
+		bnMin, bnMax := uint64(partition.BnMin.Int64), uint64(partition.BnMax.Int64)
+		if bnMin > bnMax {
+			return nil, nil, errors.Errorf(
+				"invalid bn range [%v, %v] for entity %q partition %v",
+				bnMin, bnMax, entity, partition.Index,
+			)
 		}
 
-		partitions, err := readOverlap(ctx, entity, searchRange)
-		if ctx.Err() != nil {
-			return nil, nil, store.ErrGetLogsTimeout
-		}
-		if err != nil {
-			return nil, nil, err
-		}
-
-		after, err := readRange(ctx, entity)
-		if ctx.Err() != nil {
-			return nil, nil, store.ErrGetLogsTimeout
-		}
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if before != after {
+		if i == 0 {
 			continue
 		}
 
-		if !before.existed || searchRange.From > before.end {
-			return nil, &searchRange, nil
+		previous := metadata[i-1]
+		if partition.Index <= previous.Index || partition.Index-previous.Index != 1 {
+			return nil, nil, errors.Errorf(
+				"bn partition metadata index gap for entity %q between partitions %v and %v",
+				entity, previous.Index, partition.Index,
+			)
 		}
 
-		var uncoverings *types.RangeUint64
-		if searchRange.To > before.end && searchRange.From < before.end {
-			uncoverings = &types.RangeUint64{
-				From: before.end + 1,
-				To:   searchRange.To,
-			}
+		previousEnd := uint64(previous.BnMax.Int64)
+		if bnMin <= previousEnd {
+			return nil, nil, errors.Errorf(
+				"overlapping bn partition metadata for entity %q between partitions %v and %v",
+				entity, previous.Index, partition.Index,
+			)
 		}
-
-		return partitions, uncoverings, nil
 	}
+
+	bnStart := uint64(metadata[0].BnMin.Int64)
+	bnEnd := uint64(metadata[len(metadata)-1].BnMax.Int64)
+	bnPartRange := types.RangeUint64{From: bnStart, To: bnEnd}
+	if searchRange.From < bnStart {
+		return nil, nil, errBnPartitionsPruned(searchRange, bnPartRange)
+	}
+	if searchRange.From > bnEnd {
+		return nil, &searchRange, nil
+	}
+
+	partitions := make([]*bnPartition, 0, 2)
+	for _, partition := range metadata {
+		bnMin, bnMax := uint64(partition.BnMin.Int64), uint64(partition.BnMax.Int64)
+		if bnMin <= searchRange.To && bnMax >= searchRange.From {
+			partitions = append(partitions, partition)
+		}
+	}
+
+	var uncoverings *types.RangeUint64
+	if searchRange.To > bnEnd {
+		uncoverings = &types.RangeUint64{From: bnEnd + 1, To: searchRange.To}
+	}
+
+	return partitions, uncoverings, nil
 }
 
 // searchOverlapPartitions search entity partitions that overlap the search range regardless of the boundary.

--- a/store/mysql/store_common_partition_bn.go
+++ b/store/mysql/store_common_partition_bn.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"time"
 
@@ -158,59 +159,122 @@ func (bnps *bnPartitionedStore) shrinkPartition(entity string, tabler schema.Tab
 
 // searchPartitions searches for the partitions which hold the entity data covering the specified block range.
 //
-// If the search block range [sbn0, sbn1] overlaps with any area before the block range [bn0, bn1]
-// covered by all entity partitions (sbn1 < bn0 or sbn0 < bn0 < sbn1), it will regard the entity data
+// If the lower bound of the search block range [sbn0, sbn1] precedes the lower bound of the block
+// range [bn0, bn1] covered by all entity partitions (sbn0 < bn0), it will regard the entity data
 // for the search block range as already pruned and raise an error.
 //
 // Otherwise, it will return the partitions (usually span at most two partitions) which hold the entity data
 // for the search block range and the block range which is not covered by any entity partition.
-func (bnps *bnPartitionedStore) searchPartitions(entity string, searchRange types.RangeUint64) (
+func (bnps *bnPartitionedStore) searchPartitions(
+	ctx context.Context, entity string, searchRange types.RangeUint64,
+) (
 	partitions []*bnPartition, uncoverings *types.RangeUint64, err error,
 ) {
-	bnStart, bnEnd, existed, err := bnps.bnRange(entity)
-	if err != nil {
-		return nil, nil, err
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, store.TimeoutGetLogs)
+		defer cancel()
 	}
 
-	if !existed { // no partitions found
-		return nil, &searchRange, nil
+	readRange := func(ctx context.Context, entity string) (bnPartitionRangeSnapshot, error) {
+		bnStart, bnEnd, existed, err := bnps.bnRangeWithContext(ctx, entity)
+		return bnPartitionRangeSnapshot{start: bnStart, end: bnEnd, existed: existed}, err
+	}
+	readOverlap := func(
+		ctx context.Context, entity string, searchRange types.RangeUint64,
+	) ([]*bnPartition, error) {
+		return bnps.searchOverlapPartitionsWithContext(ctx, entity, searchRange)
 	}
 
-	bnPartRange := types.RangeUint64{From: bnStart, To: bnEnd}
+	return searchPartitionsUntilStable(ctx, entity, searchRange, readRange, readOverlap)
+}
 
-	if searchRange.To < bnStart {
-		// search range is before the first partition
-		return nil, nil, errBnPartitionsPruned(searchRange, bnPartRange)
-	}
+type bnPartitionRangeSnapshot struct {
+	start   uint64
+	end     uint64
+	existed bool
+}
 
-	if searchRange.From > bnEnd {
-		// search range is after the last partition
-		return nil, &searchRange, nil
-	}
+type bnPartitionRangeReader func(context.Context, string) (bnPartitionRangeSnapshot, error)
 
-	if searchRange.From < bnStart && searchRange.To > bnStart {
-		// search range intersects with the first partition
-		return nil, nil, errBnPartitionsPruned(searchRange, bnPartRange)
-	}
+type bnPartitionOverlapReader func(context.Context, string, types.RangeUint64) ([]*bnPartition, error)
 
-	partitions, err = bnps.searchOverlapPartitions(entity, searchRange)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if searchRange.To > bnEnd && searchRange.From < bnEnd {
-		// search range intersects with the last partition
-		uncoverings = &types.RangeUint64{
-			From: bnEnd + 1, To: searchRange.To,
+// searchPartitionsUntilStable makes sure the partition metadata used for routing did not change
+// while the overlapping partitions were being selected. Partition pruning advances the covered
+// range monotonically, so retrying until two consecutive range reads match prevents returning a
+// partial result selected from stale metadata.
+func searchPartitionsUntilStable(
+	ctx context.Context,
+	entity string,
+	searchRange types.RangeUint64,
+	readRange bnPartitionRangeReader,
+	readOverlap bnPartitionOverlapReader,
+) ([]*bnPartition, *types.RangeUint64, error) {
+	for {
+		if ctx.Err() != nil {
+			return nil, nil, store.ErrGetLogsTimeout
 		}
-	}
 
-	return
+		before, err := readRange(ctx, entity)
+		if ctx.Err() != nil {
+			return nil, nil, store.ErrGetLogsTimeout
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if before.existed && searchRange.From < before.start {
+			// Pruning only advances the lower bound, so this range cannot become queryable
+			// after another metadata read and may fail without selecting overlap partitions.
+			bnPartRange := types.RangeUint64{From: before.start, To: before.end}
+			return nil, nil, errBnPartitionsPruned(searchRange, bnPartRange)
+		}
+
+		partitions, err := readOverlap(ctx, entity, searchRange)
+		if ctx.Err() != nil {
+			return nil, nil, store.ErrGetLogsTimeout
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		after, err := readRange(ctx, entity)
+		if ctx.Err() != nil {
+			return nil, nil, store.ErrGetLogsTimeout
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if before != after {
+			continue
+		}
+
+		if !before.existed || searchRange.From > before.end {
+			return nil, &searchRange, nil
+		}
+
+		var uncoverings *types.RangeUint64
+		if searchRange.To > before.end && searchRange.From < before.end {
+			uncoverings = &types.RangeUint64{
+				From: before.end + 1,
+				To:   searchRange.To,
+			}
+		}
+
+		return partitions, uncoverings, nil
+	}
 }
 
 // searchOverlapPartitions search entity partitions that overlap the search range regardless of the boundary.
 func (bnps *bnPartitionedStore) searchOverlapPartitions(entity string, searchRange types.RangeUint64) ([]*bnPartition, error) {
-	db := bnps.db.Where("entity = ?", entity).
+	return bnps.searchOverlapPartitionsWithContext(context.Background(), entity, searchRange)
+}
+
+func (bnps *bnPartitionedStore) searchOverlapPartitionsWithContext(
+	ctx context.Context, entity string, searchRange types.RangeUint64,
+) ([]*bnPartition, error) {
+	db := bnps.db.WithContext(ctx).Where("entity = ?", entity).
 		Where("bn_min <= ? AND bn_max >= ?", searchRange.To, searchRange.From).
 		Order("pi asc")
 
@@ -398,18 +462,32 @@ func (bnps *bnPartitionedStore) indexRange(entity string) (
 func (bnps *bnPartitionedStore) bnRange(entity string) (
 	start uint64, end uint64, existed bool, err error,
 ) {
-	return bnps.entityRange("MAX(bn_max) AS max, MIN(bn_min) AS min", entity)
+	return bnps.bnRangeWithContext(context.Background(), entity)
+}
+
+func (bnps *bnPartitionedStore) bnRangeWithContext(ctx context.Context, entity string) (
+	start uint64, end uint64, existed bool, err error,
+) {
+	return bnps.entityRangeWithDB(
+		bnps.db.WithContext(ctx), "MAX(bn_max) AS max, MIN(bn_min) AS min", entity,
+	)
 }
 
 // range returns entity range covered by partitions.
 func (bnps *bnPartitionedStore) entityRange(selector string, entity string) (
 	start uint64, end uint64, existed bool, err error,
 ) {
+	return bnps.entityRangeWithDB(bnps.db, selector, entity)
+}
+
+func (bnps *bnPartitionedStore) entityRangeWithDB(db *gorm.DB, selector string, entity string) (
+	start uint64, end uint64, existed bool, err error,
+) {
 	var er struct {
 		Max, Min sql.NullInt64
 	}
 
-	db := bnps.db.Select(selector).Model(&bnPartition{}).Where("entity = ?", entity)
+	db = db.Select(selector).Model(&bnPartition{}).Where("entity = ?", entity)
 	if err = db.Find(&er).Error; err != nil {
 		return
 	}

--- a/store/mysql/store_common_partition_bn_test.go
+++ b/store/mysql/store_common_partition_bn_test.go
@@ -2,171 +2,235 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
-func TestSearchPartitionsLowerBoundaryInclusive(t *testing.T) {
-	readRange := scriptedBnRangeReader(
-		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
-		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
-	)
-	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
-		t.Fatal("overlap query must not run for a pruned range")
-		return nil, nil
-	}
+func TestSearchPartitionsUsesSingleMetadataQuery(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&bnPartition{}))
+	require.NoError(t, db.Create([]bnPartition{
+		{
+			Entity: "logs", Index: 3,
+			BnMin: sql.NullInt64{Int64: 100, Valid: true},
+			BnMax: sql.NullInt64{Int64: 149, Valid: true},
+		},
+		{
+			Entity: "logs", Index: 4,
+			BnMin: sql.NullInt64{Int64: 150, Valid: true},
+			BnMax: sql.NullInt64{Int64: 199, Valid: true},
+		},
+	}).Error)
 
-	_, _, err := searchPartitionsUntilStable(
-		context.Background(), "logs", types.RangeUint64{From: 99, To: 100}, readRange, readOverlap,
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, store.ErrAlreadyPruned)
-}
+	queryCount := 0
+	require.NoError(t, db.Callback().Query().Before("gorm:query").Register(
+		"test:count-search-partition-queries", func(*gorm.DB) { queryCount++ },
+	))
 
-func TestSearchPartitionsRetriesUntilMetadataStable(t *testing.T) {
-	readRange := scriptedBnRangeReader(
-		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
-		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
-		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
-		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
-	)
-
-	overlapCalls := 0
-	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
-		overlapCalls++
-		return []*bnPartition{{Index: uint32(overlapCalls)}}, nil
-	}
-
-	partitions, _, err := searchPartitionsUntilStable(
-		context.Background(), "logs", types.RangeUint64{From: 150, To: 160}, readRange, readOverlap,
+	partitionStore := newBnPartitionedStore(db)
+	partitions, uncoverings, err := partitionStore.searchPartitions(
+		context.Background(), "logs", types.RangeUint64{From: 140, To: 160},
 	)
 	require.NoError(t, err)
-	require.Len(t, partitions, 1)
-	assert.Equal(t, uint32(2), partitions[0].Index)
-	assert.Equal(t, 2, overlapCalls)
+	assert.Equal(t, []uint32{3, 4}, partitionIndexes(partitions))
+	assert.Nil(t, uncoverings)
+	assert.Equal(t, 1, queryCount)
 }
 
-func TestSearchPartitionsRangeFingerprint(t *testing.T) {
+func TestSearchPartitionsFromMetadata(t *testing.T) {
+	metadata := []*bnPartition{
+		newTestBnPartition(3, 100, 149),
+		newTestBnPartition(4, 150, 199),
+		newTestBnPartition(5, 200, 249),
+	}
+
 	tests := []struct {
-		name      string
-		snapshots []bnPartitionRangeSnapshot
+		name              string
+		searchRange       types.RangeUint64
+		wantIndexes       []uint32
+		wantUncoverings   *types.RangeUint64
+		wantAlreadyPruned bool
 	}{
 		{
-			name: "end changed",
-			snapshots: []bnPartitionRangeSnapshot{
-				{start: 100, end: 200, existed: true},
-				{start: 100, end: 201, existed: true},
-				{start: 100, end: 201, existed: true},
-				{start: 100, end: 201, existed: true},
+			name:              "closed lower boundary is pruned",
+			searchRange:       types.RangeUint64{From: 99, To: 100},
+			wantAlreadyPruned: true,
+		},
+		{
+			name:        "range within one partition",
+			searchRange: types.RangeUint64{From: 110, To: 120},
+			wantIndexes: []uint32{3},
+		},
+		{
+			name:        "range spans adjacent partitions",
+			searchRange: types.RangeUint64{From: 140, To: 210},
+			wantIndexes: []uint32{3, 4, 5},
+		},
+		{
+			name:            "range ends after metadata",
+			searchRange:     types.RangeUint64{From: 240, To: 260},
+			wantIndexes:     []uint32{5},
+			wantUncoverings: &types.RangeUint64{From: 250, To: 260},
+		},
+		{
+			name:            "range starts at metadata end",
+			searchRange:     types.RangeUint64{From: 249, To: 260},
+			wantIndexes:     []uint32{5},
+			wantUncoverings: &types.RangeUint64{From: 250, To: 260},
+		},
+		{
+			name:            "range starts after metadata",
+			searchRange:     types.RangeUint64{From: 250, To: 260},
+			wantUncoverings: &types.RangeUint64{From: 250, To: 260},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			partitions, uncoverings, err := searchPartitionsFromMetadata(
+				"logs", test.searchRange, metadata,
+			)
+			if test.wantAlreadyPruned {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, store.ErrAlreadyPruned)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, test.wantIndexes, partitionIndexes(partitions))
+			assert.Equal(t, test.wantUncoverings, uncoverings)
+		})
+	}
+}
+
+func TestSearchPartitionsFromEmptyMetadata(t *testing.T) {
+	searchRange := types.RangeUint64{From: 100, To: 200}
+	partitions, uncoverings, err := searchPartitionsFromMetadata("logs", searchRange, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, partitions)
+	assert.Equal(t, &searchRange, uncoverings)
+}
+
+func TestSearchPartitionsFromMetadataRejectsDiscontinuity(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata []*bnPartition
+	}{
+		{
+			name: "partition index gap",
+			metadata: []*bnPartition{
+				newTestBnPartition(3, 100, 149),
+				newTestBnPartition(5, 150, 199),
 			},
 		},
 		{
-			name: "existence changed",
-			snapshots: []bnPartitionRangeSnapshot{
-				{existed: false},
-				{start: 100, end: 200, existed: true},
-				{start: 100, end: 200, existed: true},
-				{start: 100, end: 200, existed: true},
+			name: "overlapping block ranges",
+			metadata: []*bnPartition{
+				newTestBnPartition(3, 100, 150),
+				newTestBnPartition(4, 150, 199),
+			},
+		},
+		{
+			name: "inverted block range",
+			metadata: []*bnPartition{
+				newTestBnPartition(3, 150, 100),
+			},
+		},
+		{
+			name: "invalid range metadata",
+			metadata: []*bnPartition{
+				{Index: 3},
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			overlapCalls := 0
-			readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
-				overlapCalls++
-				return []*bnPartition{{Index: uint32(overlapCalls)}}, nil
-			}
-
-			partitions, _, err := searchPartitionsUntilStable(
-				context.Background(), "logs", types.RangeUint64{From: 150, To: 160},
-				scriptedBnRangeReader(test.snapshots...), readOverlap,
+			_, _, err := searchPartitionsFromMetadata(
+				"logs", types.RangeUint64{From: 100, To: 199}, test.metadata,
 			)
-			require.NoError(t, err)
-			require.Len(t, partitions, 1)
-			assert.Equal(t, uint32(2), partitions[0].Index)
-			assert.Equal(t, 2, overlapCalls)
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, store.ErrAlreadyPruned)
 		})
 	}
 }
 
-func TestSearchPartitionsRetriesWithoutFixedAttemptLimit(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func TestSearchPartitionsFromMetadataAllowsBlockGaps(t *testing.T) {
+	metadata := []*bnPartition{
+		newTestBnPartition(3, 100, 149),
+		newTestBnPartition(4, 200, 249),
+	}
 
-	rangeReads := 0
-	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
-		rangeReads++
-		if rangeReads == 8 {
-			cancel()
+	t.Run("range inside a no-data gap has no overlapping partition", func(t *testing.T) {
+		partitions, uncoverings, err := searchPartitionsFromMetadata(
+			"logs", types.RangeUint64{From: 160, To: 170}, metadata,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, partitions)
+		assert.Nil(t, uncoverings)
+	})
+
+	t.Run("range spanning a no-data gap routes both partitions", func(t *testing.T) {
+		partitions, uncoverings, err := searchPartitionsFromMetadata(
+			"logs", types.RangeUint64{From: 140, To: 210}, metadata,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []uint32{3, 4}, partitionIndexes(partitions))
+		assert.Nil(t, uncoverings)
+	})
+}
+
+func TestSearchPartitionsPruningSnapshotOutcomes(t *testing.T) {
+	searchRange := types.RangeUint64{From: 50, To: 60}
+
+	t.Run("snapshot before pruning routes the retained partition", func(t *testing.T) {
+		metadata := []*bnPartition{
+			newTestBnPartition(0, 0, 99),
+			newTestBnPartition(1, 100, 199),
 		}
-		return bnPartitionRangeSnapshot{
-			start:   uint64(rangeReads),
-			end:     100,
-			existed: true,
-		}, nil
-	}
-	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
-		return []*bnPartition{{Index: 1}}, nil
-	}
 
-	_, _, err := searchPartitionsUntilStable(
-		ctx, "logs", types.RangeUint64{From: 50, To: 60}, readRange, readOverlap,
-	)
-	assert.ErrorIs(t, err, store.ErrGetLogsTimeout)
-	assert.GreaterOrEqual(t, rangeReads, 8)
-}
+		partitions, uncoverings, err := searchPartitionsFromMetadata("logs", searchRange, metadata)
+		require.NoError(t, err)
+		assert.Equal(t, []uint32{0}, partitionIndexes(partitions))
+		assert.Nil(t, uncoverings)
+	})
 
-func TestSearchPartitionsDoesNotRetryOrdinaryErrors(t *testing.T) {
-	expectedErr := errors.New("database unavailable")
-	rangeCalls := 0
-	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
-		rangeCalls++
-		return bnPartitionRangeSnapshot{}, expectedErr
-	}
-
-	_, _, err := searchPartitionsUntilStable(
-		context.Background(), "logs", types.RangeUint64{From: 1, To: 2}, readRange, nil,
-	)
-	assert.ErrorIs(t, err, expectedErr)
-	assert.Equal(t, 1, rangeCalls)
-}
-
-func TestSearchPartitionsDoesNotRetryOverlapErrors(t *testing.T) {
-	expectedErr := errors.New("database unavailable")
-	rangeCalls := 0
-	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
-		rangeCalls++
-		return bnPartitionRangeSnapshot{start: 1, end: 100, existed: true}, nil
-	}
-	overlapCalls := 0
-	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
-		overlapCalls++
-		return nil, expectedErr
-	}
-
-	_, _, err := searchPartitionsUntilStable(
-		context.Background(), "logs", types.RangeUint64{From: 1, To: 2}, readRange, readOverlap,
-	)
-	assert.ErrorIs(t, err, expectedErr)
-	assert.Equal(t, 1, rangeCalls)
-	assert.Equal(t, 1, overlapCalls)
-}
-
-func scriptedBnRangeReader(snapshots ...bnPartitionRangeSnapshot) bnPartitionRangeReader {
-	index := 0
-	return func(context.Context, string) (bnPartitionRangeSnapshot, error) {
-		if index >= len(snapshots) {
-			return snapshots[len(snapshots)-1], nil
+	t.Run("snapshot after pruning reports the range as pruned", func(t *testing.T) {
+		metadata := []*bnPartition{
+			newTestBnPartition(1, 100, 199),
 		}
-		snapshot := snapshots[index]
-		index++
-		return snapshot, nil
+
+		_, _, err := searchPartitionsFromMetadata("logs", searchRange, metadata)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, store.ErrAlreadyPruned)
+	})
+}
+
+func newTestBnPartition(index uint32, from, to int64) *bnPartition {
+	return &bnPartition{
+		Index: index,
+		BnMin: sql.NullInt64{Int64: from, Valid: true},
+		BnMax: sql.NullInt64{Int64: to, Valid: true},
 	}
+}
+
+func partitionIndexes(partitions []*bnPartition) []uint32 {
+	if len(partitions) == 0 {
+		return nil
+	}
+
+	indexes := make([]uint32, 0, len(partitions))
+	for _, partition := range partitions {
+		indexes = append(indexes, partition.Index)
+	}
+	return indexes
 }

--- a/store/mysql/store_common_partition_bn_test.go
+++ b/store/mysql/store_common_partition_bn_test.go
@@ -1,0 +1,172 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Conflux-Chain/confura/store"
+	"github.com/Conflux-Chain/confura/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchPartitionsLowerBoundaryInclusive(t *testing.T) {
+	readRange := scriptedBnRangeReader(
+		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
+		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
+	)
+	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
+		t.Fatal("overlap query must not run for a pruned range")
+		return nil, nil
+	}
+
+	_, _, err := searchPartitionsUntilStable(
+		context.Background(), "logs", types.RangeUint64{From: 99, To: 100}, readRange, readOverlap,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrAlreadyPruned)
+}
+
+func TestSearchPartitionsRetriesUntilMetadataStable(t *testing.T) {
+	readRange := scriptedBnRangeReader(
+		bnPartitionRangeSnapshot{start: 100, end: 200, existed: true},
+		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
+		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
+		bnPartitionRangeSnapshot{start: 150, end: 200, existed: true},
+	)
+
+	overlapCalls := 0
+	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
+		overlapCalls++
+		return []*bnPartition{{Index: uint32(overlapCalls)}}, nil
+	}
+
+	partitions, _, err := searchPartitionsUntilStable(
+		context.Background(), "logs", types.RangeUint64{From: 150, To: 160}, readRange, readOverlap,
+	)
+	require.NoError(t, err)
+	require.Len(t, partitions, 1)
+	assert.Equal(t, uint32(2), partitions[0].Index)
+	assert.Equal(t, 2, overlapCalls)
+}
+
+func TestSearchPartitionsRangeFingerprint(t *testing.T) {
+	tests := []struct {
+		name      string
+		snapshots []bnPartitionRangeSnapshot
+	}{
+		{
+			name: "end changed",
+			snapshots: []bnPartitionRangeSnapshot{
+				{start: 100, end: 200, existed: true},
+				{start: 100, end: 201, existed: true},
+				{start: 100, end: 201, existed: true},
+				{start: 100, end: 201, existed: true},
+			},
+		},
+		{
+			name: "existence changed",
+			snapshots: []bnPartitionRangeSnapshot{
+				{existed: false},
+				{start: 100, end: 200, existed: true},
+				{start: 100, end: 200, existed: true},
+				{start: 100, end: 200, existed: true},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			overlapCalls := 0
+			readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
+				overlapCalls++
+				return []*bnPartition{{Index: uint32(overlapCalls)}}, nil
+			}
+
+			partitions, _, err := searchPartitionsUntilStable(
+				context.Background(), "logs", types.RangeUint64{From: 150, To: 160},
+				scriptedBnRangeReader(test.snapshots...), readOverlap,
+			)
+			require.NoError(t, err)
+			require.Len(t, partitions, 1)
+			assert.Equal(t, uint32(2), partitions[0].Index)
+			assert.Equal(t, 2, overlapCalls)
+		})
+	}
+}
+
+func TestSearchPartitionsRetriesWithoutFixedAttemptLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rangeReads := 0
+	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
+		rangeReads++
+		if rangeReads == 8 {
+			cancel()
+		}
+		return bnPartitionRangeSnapshot{
+			start:   uint64(rangeReads),
+			end:     100,
+			existed: true,
+		}, nil
+	}
+	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
+		return []*bnPartition{{Index: 1}}, nil
+	}
+
+	_, _, err := searchPartitionsUntilStable(
+		ctx, "logs", types.RangeUint64{From: 50, To: 60}, readRange, readOverlap,
+	)
+	assert.ErrorIs(t, err, store.ErrGetLogsTimeout)
+	assert.GreaterOrEqual(t, rangeReads, 8)
+}
+
+func TestSearchPartitionsDoesNotRetryOrdinaryErrors(t *testing.T) {
+	expectedErr := errors.New("database unavailable")
+	rangeCalls := 0
+	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
+		rangeCalls++
+		return bnPartitionRangeSnapshot{}, expectedErr
+	}
+
+	_, _, err := searchPartitionsUntilStable(
+		context.Background(), "logs", types.RangeUint64{From: 1, To: 2}, readRange, nil,
+	)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, rangeCalls)
+}
+
+func TestSearchPartitionsDoesNotRetryOverlapErrors(t *testing.T) {
+	expectedErr := errors.New("database unavailable")
+	rangeCalls := 0
+	readRange := func(context.Context, string) (bnPartitionRangeSnapshot, error) {
+		rangeCalls++
+		return bnPartitionRangeSnapshot{start: 1, end: 100, existed: true}, nil
+	}
+	overlapCalls := 0
+	readOverlap := func(context.Context, string, types.RangeUint64) ([]*bnPartition, error) {
+		overlapCalls++
+		return nil, expectedErr
+	}
+
+	_, _, err := searchPartitionsUntilStable(
+		context.Background(), "logs", types.RangeUint64{From: 1, To: 2}, readRange, readOverlap,
+	)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Equal(t, 1, rangeCalls)
+	assert.Equal(t, 1, overlapCalls)
+}
+
+func scriptedBnRangeReader(snapshots ...bnPartitionRangeSnapshot) bnPartitionRangeReader {
+	index := 0
+	return func(context.Context, string) (bnPartitionRangeSnapshot, error) {
+		if index >= len(snapshots) {
+			return snapshots[len(snapshots)-1], nil
+		}
+		snapshot := snapshots[index]
+		index++
+		return snapshot, nil
+	}
+}

--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -170,7 +170,7 @@ func (ls *logStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 func (ls *logStore[T]) GetLogs(ctx context.Context, storeFilter store.LogFilter) ([]*store.Log, error) {
 	// find the partitions that holds the event logs
 	partitions, _, err := ls.searchPartitions(
-		bnPartitionedLogEntity, types.RangeUint64{
+		ctx, bnPartitionedLogEntity, types.RangeUint64{
 			From: storeFilter.BlockFrom,
 			To:   storeFilter.BlockTo,
 		},

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -121,20 +121,21 @@ func (bcls *bigContractLogStore[T]) preparePartitions(dataSlice []T) (map[uint64
 
 // migrate migrates address indexed event logs for the big contract to separate log table partition.
 func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPartition) error {
-	var bnMin, bnMax uint64
-
-	if eBlockmap, ok, err := bcls.ebms.EarliestBlockMapping(); err != nil {
-		return errors.WithMessage(err, "failed to get earliest block mapping")
-	} else if ok {
-		bnMin = eBlockmap.BnMin
-	}
-
 	aiTableName := bcls.ails.GetPartitionedTableName(contract.Address)
 
 	clEntity, clTabler := bcls.contractEntity(contract.ID), bcls.contractTabler(contract.ID)
 	clTableName := bcls.getPartitionedTableName(clTabler, partition.Index)
 
 	return bcls.db.Transaction(func(dbTx *gorm.DB) error {
+		eBlockMap, ok, err := bcls.ebms.earliestBlockMapping(dbTx)
+		if err != nil {
+			return errors.WithMessage(err, "failed to get earliest block mapping")
+		}
+		if !ok {
+			return errors.New("earliest block mapping not found")
+		}
+
+		bnMin, bnMax := eBlockMap.BnMin, uint64(0)
 		var aiLogs []*AddressIndexedLog
 
 		aidb := dbTx.Table(aiTableName).Where("cid = ?", contract.ID)
@@ -171,6 +172,9 @@ func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPart
 		if err := res.Error; err != nil {
 			return errors.WithMessage(err, "failed to batch get address indexed logs for migration")
 		}
+		if res.RowsAffected == 0 {
+			return errors.New("no address indexed logs found for migration")
+		}
 
 		// validate migration block range
 		if bnMin > bnMax {
@@ -185,8 +189,9 @@ func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPart
 		}
 
 		// update separate contract log partition count
-		err := bcls.deltaUpdateCount(dbTx, clEntity, int(partition.Index), int(res.RowsAffected))
-		if err != nil {
+		if err := bcls.deltaUpdateCount(
+			dbTx, clEntity, int(partition.Index), int(res.RowsAffected),
+		); err != nil {
 			return errors.WithMessage(err, "failed to update contract log partition count")
 		}
 

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -121,6 +121,14 @@ func (bcls *bigContractLogStore[T]) preparePartitions(dataSlice []T) (map[uint64
 
 // migrate migrates address indexed event logs for the big contract to separate log table partition.
 func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPartition) error {
+	var bnMin, bnMax uint64
+
+	if eBlockmap, ok, err := bcls.ebms.EarliestBlockMapping(); err != nil {
+		return errors.WithMessage(err, "failed to get earliest block mapping")
+	} else if ok {
+		bnMin = eBlockmap.BnMin
+	}
+
 	aiTableName := bcls.ails.GetPartitionedTableName(contract.Address)
 
 	clEntity, clTabler := bcls.contractEntity(contract.ID), bcls.contractTabler(contract.ID)
@@ -128,15 +136,15 @@ func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPart
 
 	return bcls.db.Transaction(func(dbTx *gorm.DB) error {
 		var aiLogs []*AddressIndexedLog
-		var bnMin, bnMax uint64
 
 		aidb := dbTx.Table(aiTableName).Where("cid = ?", contract.ID)
-
-		res := aidb.FindInBatches(&aiLogs, defaultBatchSizeForLogMigrating, func(tx *gorm.DB, batch int) error {
+		res := aidb.FindInBatches(&aiLogs, defaultBatchSizeForLogMigrating, func(_ *gorm.DB, _ int) error {
 			deleteIds := make([]uint64, 0, len(aiLogs))
 			clLogs := make([]*contractLog, 0, len(aiLogs))
 
 			for _, aiLog := range aiLogs {
+				bnMax = max(bnMax, aiLog.BlockNumber)
+
 				// copy address indexed event log
 				clog := (contractLog)(*aiLog)
 				// clear primary id
@@ -157,11 +165,6 @@ func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPart
 				return errors.WithMessage(err, "failed to delete address indexed log")
 			}
 
-			if batch == 1 { // least block number of the first batch
-				bnMin = aiLogs[0].BlockNumber
-			}
-			bnMax = aiLogs[len(aiLogs)-1].BlockNumber
-
 			return nil
 		})
 
@@ -169,8 +172,15 @@ func (bcls *bigContractLogStore[T]) migrate(contract *Contract, partition bnPart
 			return errors.WithMessage(err, "failed to batch get address indexed logs for migration")
 		}
 
+		// validate migration block range
+		if bnMin > bnMax {
+			return errors.Errorf(
+				"first covered block %v exceeds last indexed block %v", bnMin, bnMax,
+			)
+		}
+
 		// expand partition block number range
-		if err := bcls.expandBnRange(dbTx, clEntity, int(partition.Index), 0, bnMax); err != nil {
+		if err := bcls.expandBnRange(dbTx, clEntity, int(partition.Index), bnMin, bnMax); err != nil {
 			return errors.WithMessage(err, "failed to expand partition bn range")
 		}
 
@@ -370,7 +380,7 @@ func (bcls *bigContractLogStore[T]) GetContractLogs(
 ) ([]*store.Log, error) {
 	contractEntity := bcls.contractEntity(cid)
 	partitions, _, err := bcls.searchPartitions(
-		contractEntity, types.RangeUint64{
+		ctx, contractEntity, types.RangeUint64{
 			From: storeFilter.BlockFrom,
 			To:   storeFilter.BlockTo,
 		},

--- a/store/mysql/store_log_big_migration_test.go
+++ b/store/mysql/store_log_big_migration_test.go
@@ -1,0 +1,229 @@
+package mysql
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/Conflux-Chain/confura/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type bigLogMigrationTestHarness struct {
+	db          *gorm.DB
+	partitionID uint64
+	entity      string
+	sourceTable string
+	targetTable string
+	migrate     func() error
+}
+
+func TestBigLogMigrationRangeValidation(t *testing.T) {
+	kinds := []struct {
+		name    string
+		factory func(*testing.T, *epochBlockMap, []uint64) *bigLogMigrationTestHarness
+	}{
+		{name: "contract", factory: newBigContractMigrationTestHarness},
+		{name: "topic", factory: newBigTopicMigrationTestHarness},
+	}
+
+	tests := []struct {
+		name          string
+		mapping       *epochBlockMap
+		sourceBlocks  []uint64
+		wantErr       string
+		wantSource    int64
+		wantTarget    int64
+		wantBnMin     sql.NullInt64
+		wantBnMax     sql.NullInt64
+		wantPartCount uint32
+	}{
+		{
+			name:         "missing mapping fails closed",
+			sourceBlocks: []uint64{150},
+			wantErr:      "earliest block mapping not found",
+			wantSource:   1,
+		},
+		{
+			name:    "empty source fails closed",
+			mapping: testEpochBlockMapping(10, 100, 109),
+			wantErr: "indexed logs found for migration",
+		},
+		{
+			name:         "inverted range rolls back",
+			mapping:      testEpochBlockMapping(20, 200, 209),
+			sourceBlocks: []uint64{150},
+			wantErr:      "first covered block 200 exceeds last indexed block 150",
+			wantSource:   1,
+		},
+		{
+			name:          "valid range migrates",
+			mapping:       testEpochBlockMapping(10, 100, 109),
+			sourceBlocks:  []uint64{150, 160},
+			wantSource:    0,
+			wantTarget:    2,
+			wantBnMin:     sql.NullInt64{Int64: 100, Valid: true},
+			wantBnMax:     sql.NullInt64{Int64: 160, Valid: true},
+			wantPartCount: 2,
+		},
+	}
+
+	for _, kind := range kinds {
+		kind := kind
+		t.Run(kind.name, func(t *testing.T) {
+			for _, test := range tests {
+				test := test
+				t.Run(test.name, func(t *testing.T) {
+					harness := kind.factory(t, test.mapping, test.sourceBlocks)
+					err := harness.migrate()
+					if test.wantErr != "" {
+						require.Error(t, err)
+						assert.ErrorContains(t, err, test.wantErr)
+					} else {
+						require.NoError(t, err)
+					}
+
+					assertMigrationState(t, harness, test.wantSource, test.wantTarget,
+						test.wantBnMin, test.wantBnMax, test.wantPartCount)
+				})
+			}
+		})
+	}
+}
+
+func newBigContractMigrationTestHarness(
+	t *testing.T, mapping *epochBlockMap, sourceBlocks []uint64,
+) *bigLogMigrationTestHarness {
+	t.Helper()
+
+	db := newBigLogMigrationTestDB(t)
+	mapStore := &epochBlockMapStore[store.EpochData]{baseStore: newBaseStore(db)}
+	addressStore := NewAddressIndexedLogStore[store.EpochData](db, nil, nil, 1)
+	contractStore := &bigContractLogStore[store.EpochData]{
+		bnPartitionedStore: newBnPartitionedStore(db),
+		ebms:               mapStore,
+		ails:               addressStore,
+	}
+
+	contract := &Contract{ID: 1, Address: "0x1"}
+	partition := createBigLogMigrationTables(
+		t, db, contractStore.contractEntity(contract.ID),
+		&AddressIndexedLog{}, contractStore.contractTabler(contract.ID),
+	)
+	if mapping != nil {
+		require.NoError(t, db.Create(mapping).Error)
+	}
+
+	sourceTable := addressStore.GetPartitionedTableName(contract.Address)
+	for _, block := range sourceBlocks {
+		require.NoError(t, db.Table(sourceTable).Create(&AddressIndexedLog{
+			ContractID: contract.ID, BlockNumber: block,
+		}).Error)
+	}
+
+	targetTable := contractStore.getPartitionedTableName(
+		contractStore.contractTabler(contract.ID), partition.Index,
+	)
+	return &bigLogMigrationTestHarness{
+		db: db, partitionID: partition.ID, entity: partition.Entity,
+		sourceTable: sourceTable, targetTable: targetTable,
+		migrate: func() error { return contractStore.migrate(contract, partition) },
+	}
+}
+
+func newBigTopicMigrationTestHarness(
+	t *testing.T, mapping *epochBlockMap, sourceBlocks []uint64,
+) *bigLogMigrationTestHarness {
+	t.Helper()
+
+	db := newBigLogMigrationTestDB(t)
+	mapStore := &epochBlockMapStore[store.EpochData]{baseStore: newBaseStore(db)}
+	topicIndexStore := NewTopicIndexedLogStore[store.EpochData](db, nil, 1)
+	topicStore := &bigTopicLogStore[store.EpochData]{
+		bnPartitionedStore: newBnPartitionedStore(db),
+		ebms:               mapStore,
+		tils:               topicIndexStore,
+	}
+
+	topic := &Topic{ID: 1, Hash: "0x1"}
+	partition := createBigLogMigrationTables(
+		t, db, topicStore.topicEntity(topic.ID),
+		&TopicIndexedLog{}, topicStore.topicTabler(topic.ID),
+	)
+	if mapping != nil {
+		require.NoError(t, db.Create(mapping).Error)
+	}
+
+	sourceTable := topicIndexStore.GetPartitionedTableName(topic.Hash)
+	for _, block := range sourceBlocks {
+		require.NoError(t, db.Table(sourceTable).Create(&TopicIndexedLog{
+			Topic0ID: topic.ID, BlockNumber: block,
+		}).Error)
+	}
+
+	targetTable := topicStore.getPartitionedTableName(topicStore.topicTabler(topic.ID), partition.Index)
+	return &bigLogMigrationTestHarness{
+		db: db, partitionID: partition.ID, entity: partition.Entity,
+		sourceTable: sourceTable, targetTable: targetTable,
+		migrate: func() error { return topicStore.migrate(topic, partition) },
+	}
+}
+
+func newBigLogMigrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dsn := filepath.Join(t.TempDir(), "migration.db") + "?_journal_mode=WAL&_busy_timeout=5000"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&epochBlockMap{}, &bnPartition{}))
+	return db
+}
+
+func createBigLogMigrationTables(
+	t *testing.T,
+	db *gorm.DB,
+	entity string,
+	sourceModel, targetModel interface{ TableName() string },
+) bnPartition {
+	t.Helper()
+
+	partitionStore := newBnPartitionedStore(db)
+	_, err := partitionStore.createPartitionedTable(db, sourceModel, 0)
+	require.NoError(t, err)
+	_, err = partitionStore.createPartitionedTable(db, targetModel, 0)
+	require.NoError(t, err)
+
+	partition := bnPartition{Entity: entity, Index: 0}
+	require.NoError(t, db.Create(&partition).Error)
+	return partition
+}
+
+func assertMigrationState(
+	t *testing.T,
+	harness *bigLogMigrationTestHarness,
+	wantSource, wantTarget int64,
+	wantBnMin, wantBnMax sql.NullInt64,
+	wantPartCount uint32,
+) {
+	t.Helper()
+
+	var sourceCount, targetCount int64
+	require.NoError(t, harness.db.Table(harness.sourceTable).Count(&sourceCount).Error)
+	require.NoError(t, harness.db.Table(harness.targetTable).Count(&targetCount).Error)
+	assert.Equal(t, wantSource, sourceCount)
+	assert.Equal(t, wantTarget, targetCount)
+
+	var partition bnPartition
+	require.NoError(t, harness.db.First(&partition, harness.partitionID).Error)
+	assert.Equal(t, harness.entity, partition.Entity)
+	assert.Equal(t, wantBnMin, partition.BnMin)
+	assert.Equal(t, wantBnMax, partition.BnMax)
+	assert.Equal(t, wantPartCount, partition.Count)
+}
+
+func testEpochBlockMapping(epoch, bnMin, bnMax uint64) *epochBlockMap {
+	return &epochBlockMap{Epoch: epoch, BnMin: bnMin, BnMax: bnMax, PivotHash: "pivot"}
+}

--- a/store/mysql/store_log_big_topic.go
+++ b/store/mysql/store_log_big_topic.go
@@ -112,6 +112,14 @@ func (btls *bigTopicLogStore[T]) preparePartitions(dataSlice []T) (map[uint64]bn
 
 // migrate moves logs from shared shard table to dedicated big topic table.
 func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) error {
+	var bnMin, bnMax uint64
+
+	if eBlockmap, ok, err := btls.ebms.EarliestBlockMapping(); err != nil {
+		return errors.WithMessage(err, "failed to get earliest block mapping")
+	} else if ok {
+		bnMin = eBlockmap.BnMin
+	}
+
 	tiTableName := btls.tils.GetPartitionedTableName(topic.Hash)
 
 	tlEntity, tlTabler := btls.topicEntity(topic.ID), btls.topicTabler(topic.ID)
@@ -119,15 +127,15 @@ func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) er
 
 	return btls.db.Transaction(func(dbTx *gorm.DB) error {
 		var tiLogs []*TopicIndexedLog
-		var bnMin, bnMax uint64
 
 		tidb := dbTx.Table(tiTableName).Where("tid = ?", topic.ID)
-
-		res := tidb.FindInBatches(&tiLogs, defaultBatchSizeForLogMigrating, func(tx *gorm.DB, batch int) error {
+		res := tidb.FindInBatches(&tiLogs, defaultBatchSizeForLogMigrating, func(_ *gorm.DB, _ int) error {
 			delIDs := make([]uint64, 0, len(tiLogs))
 			tlLogs := make([]*topicLog, 0, len(tiLogs))
 
 			for _, tilog := range tiLogs {
+				bnMax = max(bnMax, tilog.BlockNumber)
+
 				// copy topic indexed event log
 				tlog := (topicLog)(*tilog)
 				tlog.ID = 0 // clear primary id
@@ -146,12 +154,6 @@ func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) er
 				return errors.WithMessage(err, "failed to delete topic indexed logs")
 			}
 
-			// Track block range stats
-			if batch == 1 {
-				bnMin = tiLogs[0].BlockNumber
-			}
-			bnMax = tiLogs[len(tiLogs)-1].BlockNumber
-
 			return nil
 		})
 
@@ -159,8 +161,15 @@ func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) er
 			return errors.WithMessage(err, "failed to batch migrate topic indexed logs")
 		}
 
+		// validate migration block range
+		if bnMin > bnMax {
+			return errors.Errorf(
+				"first covered block %v exceeds last indexed block %v", bnMin, bnMax,
+			)
+		}
+
 		// expand partition block number range
-		if err := btls.expandBnRange(dbTx, tlEntity, int(partition.Index), 0, bnMax); err != nil {
+		if err := btls.expandBnRange(dbTx, tlEntity, int(partition.Index), bnMin, bnMax); err != nil {
 			return errors.WithMessage(err, "failed to expand partition bn range")
 		}
 
@@ -358,7 +367,7 @@ func (btls *bigTopicLogStore[T]) GetTopicLogs(
 	topic string,
 	storeFilter store.LogFilter,
 ) ([]*store.Log, error) {
-	partitions, _, err := btls.searchPartitions(btls.topicEntity(tid), types.RangeUint64{
+	partitions, _, err := btls.searchPartitions(ctx, btls.topicEntity(tid), types.RangeUint64{
 		From: storeFilter.BlockFrom,
 		To:   storeFilter.BlockTo,
 	})

--- a/store/mysql/store_log_big_topic.go
+++ b/store/mysql/store_log_big_topic.go
@@ -112,20 +112,21 @@ func (btls *bigTopicLogStore[T]) preparePartitions(dataSlice []T) (map[uint64]bn
 
 // migrate moves logs from shared shard table to dedicated big topic table.
 func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) error {
-	var bnMin, bnMax uint64
-
-	if eBlockmap, ok, err := btls.ebms.EarliestBlockMapping(); err != nil {
-		return errors.WithMessage(err, "failed to get earliest block mapping")
-	} else if ok {
-		bnMin = eBlockmap.BnMin
-	}
-
 	tiTableName := btls.tils.GetPartitionedTableName(topic.Hash)
 
 	tlEntity, tlTabler := btls.topicEntity(topic.ID), btls.topicTabler(topic.ID)
 	tlTableName := btls.getPartitionedTableName(tlTabler, partition.Index)
 
 	return btls.db.Transaction(func(dbTx *gorm.DB) error {
+		eBlockMap, ok, err := btls.ebms.earliestBlockMapping(dbTx)
+		if err != nil {
+			return errors.WithMessage(err, "failed to get earliest block mapping")
+		}
+		if !ok {
+			return errors.New("earliest block mapping not found")
+		}
+
+		bnMin, bnMax := eBlockMap.BnMin, uint64(0)
 		var tiLogs []*TopicIndexedLog
 
 		tidb := dbTx.Table(tiTableName).Where("tid = ?", topic.ID)
@@ -160,6 +161,9 @@ func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) er
 		if err := res.Error; err != nil {
 			return errors.WithMessage(err, "failed to batch migrate topic indexed logs")
 		}
+		if res.RowsAffected == 0 {
+			return errors.New("no topic indexed logs found for migration")
+		}
 
 		// validate migration block range
 		if bnMin > bnMax {
@@ -174,8 +178,9 @@ func (btls *bigTopicLogStore[T]) migrate(topic *Topic, partition bnPartition) er
 		}
 
 		// update dedicated topic log partition count
-		err := btls.deltaUpdateCount(dbTx, tlEntity, int(partition.Index), int(res.RowsAffected))
-		if err != nil {
+		if err := btls.deltaUpdateCount(
+			dbTx, tlEntity, int(partition.Index), int(res.RowsAffected),
+		); err != nil {
 			return errors.WithMessage(err, "failed to update topic log partition count")
 		}
 

--- a/store/mysql/store_log_virtual_filter.go
+++ b/store/mysql/store_log_virtual_filter.go
@@ -193,7 +193,7 @@ func (vfls *VirtualFilterLogStore) GetLogs(
 	fentity, ftabler := vfls.filterEntity(fid), vfls.filterTabler(fid)
 
 	srange := types.RangeUint64{From: sfilter.BlockFrom, To: sfilter.BlockTo}
-	partitions, _, err := vfls.searchPartitions(fentity, srange)
+	partitions, _, err := vfls.searchPartitions(ctx, fentity, srange)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to search partitions")
 	}

--- a/store/mysql/store_map_epoch_block.go
+++ b/store/mysql/store_map_epoch_block.go
@@ -151,6 +151,11 @@ func (e2bms *epochBlockMapStore[T]) EarliestBlockMapping() (epochBlockMap, bool,
 	return e2bms.findOneBlockMapping("", "epoch ASC")
 }
 
+// LatestBlockMapping returns the latest epoch block mapping.
+func (e2bms *epochBlockMapStore[T]) LatestBlockMapping() (epochBlockMap, bool, error) {
+	return e2bms.findOneBlockMapping("", "epoch DESC")
+}
+
 // LatestEpochBeforeBlock finds the latest epoch ≤ maxEpochNumber where BnMax ≤ blockNumber.
 func (e2bms *epochBlockMapStore[T]) LatestEpochBeforeBlock(maxEpochNumber, blockNumber uint64) (uint64, bool, error) {
 	res, existed, err := e2bms.findOneBlockMapping("epoch <= ? AND bn_max <= ?", "epoch DESC", maxEpochNumber, blockNumber)

--- a/store/mysql/store_map_epoch_block.go
+++ b/store/mysql/store_map_epoch_block.go
@@ -113,7 +113,15 @@ func (e2bms *epochBlockMapStore[T]) MaxEpoch() (uint64, bool, error) {
 // findOneBlockMapping retrieves a single `epochBlockMap` record based on a condition and optional ordering.
 func (e2bms *epochBlockMapStore[T]) findOneBlockMapping(
 	condition string, order string, args ...interface{}) (res epochBlockMap, existed bool, err error) {
-	query := e2bms.db
+	return e2bms.findOneBlockMappingWithDB(e2bms.db, condition, order, args...)
+}
+
+// findOneBlockMappingWithDB retrieves a mapping through the supplied DB handle so callers can
+// keep the mapping read in the same transaction snapshot as related data changes.
+func (e2bms *epochBlockMapStore[T]) findOneBlockMappingWithDB(
+	db *gorm.DB, condition string, order string, args ...interface{},
+) (res epochBlockMap, existed bool, err error) {
+	query := db
 	if condition != "" {
 		query = query.Where(condition, args...)
 	}
@@ -148,7 +156,11 @@ func (e2bms *epochBlockMapStore[T]) BlockMapping(epoch uint64) (epochBlockMap, b
 
 // EarliestBlockMapping returns the earliest epoch block mapping.
 func (e2bms *epochBlockMapStore[T]) EarliestBlockMapping() (epochBlockMap, bool, error) {
-	return e2bms.findOneBlockMapping("", "epoch ASC")
+	return e2bms.earliestBlockMapping(e2bms.db)
+}
+
+func (e2bms *epochBlockMapStore[T]) earliestBlockMapping(db *gorm.DB) (epochBlockMap, bool, error) {
+	return e2bms.findOneBlockMappingWithDB(db, "", "epoch ASC")
 }
 
 // LatestBlockMapping returns the latest epoch block mapping.

--- a/store/mysql/store_map_epoch_block.go
+++ b/store/mysql/store_map_epoch_block.go
@@ -113,8 +113,11 @@ func (e2bms *epochBlockMapStore[T]) MaxEpoch() (uint64, bool, error) {
 // findOneBlockMapping retrieves a single `epochBlockMap` record based on a condition and optional ordering.
 func (e2bms *epochBlockMapStore[T]) findOneBlockMapping(
 	condition string, order string, args ...interface{}) (res epochBlockMap, existed bool, err error) {
+	query := e2bms.db
+	if condition != "" {
+		query = query.Where(condition, args...)
+	}
 
-	query := e2bms.db.Where(condition, args...)
 	if order != "" {
 		query = query.Order(order)
 	}
@@ -141,6 +144,11 @@ func (e2bms *epochBlockMapStore[T]) CeilBlockMapping(epoch uint64) (epochBlockMa
 // BlockMapping retrieves the `epochBlockMap` for the exact given epoch.
 func (e2bms *epochBlockMapStore[T]) BlockMapping(epoch uint64) (epochBlockMap, bool, error) {
 	return e2bms.findOneBlockMapping("epoch = ?", "", epoch)
+}
+
+// EarliestBlockMapping returns the earliest epoch block mapping.
+func (e2bms *epochBlockMapStore[T]) EarliestBlockMapping() (epochBlockMap, bool, error) {
+	return e2bms.findOneBlockMapping("", "epoch ASC")
 }
 
 // LatestEpochBeforeBlock finds the latest epoch ≤ maxEpochNumber where BnMax ≤ blockNumber.

--- a/store/mysql/store_map_epoch_block_test.go
+++ b/store/mysql/store_map_epoch_block_test.go
@@ -1,0 +1,39 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/Conflux-Chain/confura/store"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEarliestBlockMappingUsesSuppliedTransaction(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&epochBlockMap{}))
+
+	mapStore := &epochBlockMapStore[store.EpochData]{baseStore: newBaseStore(db)}
+	expectedRollback := errors.New("rollback test transaction")
+	err = db.Transaction(func(dbTx *gorm.DB) error {
+		require.NoError(t, dbTx.Create(&epochBlockMap{
+			Epoch: 10, BnMin: 100, BnMax: 109, PivotHash: "pivot",
+		}).Error)
+
+		mapping, ok, err := mapStore.earliestBlockMapping(dbTx)
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, uint64(10), mapping.Epoch)
+		assert.Equal(t, uint64(100), mapping.BnMin)
+
+		return expectedRollback
+	})
+	assert.ErrorIs(t, err, expectedRollback)
+
+	_, ok, err := mapStore.EarliestBlockMapping()
+	require.NoError(t, err)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

- fix the inclusive pruning boundary so queries ending exactly at the retained partition start return `store.ErrAlreadyPruned`
- pass request contexts into `searchPartitions` and keep retrying when partition metadata changes until the context deadline expires
- add static lower-bound validation to Core Space and eSpace `splitLogFilter` routing, with pruned ranges consistently returning `store.ErrAlreadyPruned`
- use the earliest epoch-block mapping's `BnMin` as the initial range for newly migrated big contract/topic log partitions
- derive migration maxima from the existing batched migration and fail closed for empty or inverted migration results

## Root cause

Partition pruning used an open upper-bound comparison at the retained boundary, allowing a closed query range whose `To` equaled the first retained block to proceed and potentially return incomplete data. Partition metadata could also change between routing and querying. Fixed address/topic routes lacked an explicit static historical lower-bound check, and new big contract/topic partitions initialized their historical range from block zero instead of the database's actual first mapped block.

## Impact

Queries crossing the retained historical boundary now fail explicitly instead of silently returning partial results. Metadata races are retried within the caller's timeout, and fixed address/topic routing follows the same pruning semantics in Core Space and eSpace. Newly migrated big log partitions advertise the actual indexed lower bound.

## Non-goals

- no new database tables
- no schema changes
- no archive split logic
- no new prune-handler behavior

## Validation

- `go test ./...`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/406)
<!-- Reviewable:end -->
