### PR TITLE
add eSpace access list and trace call RPCs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/montanaflynn/stats v0.6.6
 	github.com/openweb3/go-rpc-provider v0.3.7
-	github.com/openweb3/web3go v0.3.5-0.20260710073340-64cb4002d445
+	github.com/openweb3/web3go v0.3.5
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ github.com/openweb3/go-rpc-provider v0.3.7 h1:MOSXJE9GCt2PpQtpFjtSlDWfn63iL2qUaS
 github.com/openweb3/go-rpc-provider v0.3.7/go.mod h1:eXd8viZzDcuvHKhl0Y14x92pGo4uzSB3Y0My5KOd+NM=
 github.com/openweb3/go-sdk-common v0.0.0-20240627072707-f78f0155ab34 h1:qLelmviLGRleOB6A8ssljatvs6K6n1BMd3PNeozNq/E=
 github.com/openweb3/go-sdk-common v0.0.0-20240627072707-f78f0155ab34/go.mod h1:YMfzbYeq1G7s6nRjcFAgYSA/Uqy5+Aa1UvL0Rbnc290=
-github.com/openweb3/web3go v0.3.5-0.20260710073340-64cb4002d445 h1:lE0ABHyZNPEIn7PVuZirA0TC723D/QIu6PAw+rNhDCk=
-github.com/openweb3/web3go v0.3.5-0.20260710073340-64cb4002d445/go.mod h1:v/ASBdIBqxjgjcr/2EIjAodIN4dy3KJ5vBTtwRDEiio=
+github.com/openweb3/web3go v0.3.5 h1:En68BNlSVnItbJfqEeyW1lykMYDgSOnAJmIo3LQIYJ8=
+github.com/openweb3/web3go v0.3.5/go.mod h1:v/ASBdIBqxjgjcr/2EIjAodIN4dy3KJ5vBTtwRDEiio=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -300,6 +300,18 @@ func (api *ethAPI) EstimateGas(
 	return (*hexutil.Big)(gas), err
 }
 
+// CreateAccessList generates an EIP-2930 access list for a transaction request.
+func (api *ethAPI) CreateAccessList(
+	ctx context.Context,
+	request web3Types.CallRequest,
+	blockNumOrHash *web3Types.BlockNumberOrHash,
+	overrides *web3Types.StateOverride,
+) (*web3Types.CreateAccessListResult, error) {
+	w3c := GetEthClientFromContext(ctx)
+	api.inputBlockMetric.Update2(blockNumOrHash, "eth_createAccessList", w3c.Eth)
+	return api.stateHandler.CreateAccessList(ctx, w3c, request, blockNumOrHash, overrides)
+}
+
 // GetTransactionByHash returns the transaction with the given hash.
 func (api *ethAPI) GetTransactionByHash(ctx context.Context, hash common.Hash) (any, error) {
 	if txn, ok := api.tryGetTxnFromStore(ctx, hash); ok && txn != nil {

--- a/rpc/eth_trace_api.go
+++ b/rpc/eth_trace_api.go
@@ -15,6 +15,16 @@ type ethTraceAPI struct {
 	stateHandler *handler.EthStateHandler
 }
 
+func (api *ethTraceAPI) Call(
+	ctx context.Context,
+	request types.CallRequest,
+	options types.TraceOptions,
+	blockNumOrHash *types.BlockNumberOrHash,
+) (types.TraceResults, error) {
+	w3c := GetEthClientFromContext(ctx)
+	return api.stateHandler.TraceCall(ctx, w3c, request, options, blockNumOrHash)
+}
+
 func (api *ethTraceAPI) Block(ctx context.Context, blockNumOrHash types.BlockNumberOrHash) (cacheTypes.Lazy[[]types.LocalizedTrace], error) {
 	w3c := GetEthClientFromContext(ctx)
 	return api.stateHandler.LazyTraceBlock(ctx, w3c, blockNumOrHash)

--- a/rpc/handler/eth_state.go
+++ b/rpc/handler/eth_state.go
@@ -110,6 +110,23 @@ func (h *EthStateHandler) EstimateGas(
 	return est, err
 }
 
+func (h *EthStateHandler) CreateAccessList(
+	ctx context.Context,
+	w3c *node.Web3goClient,
+	callRequest types.CallRequest,
+	blockNum *types.BlockNumberOrHash,
+	overrides *types.StateOverride,
+) (*types.CreateAccessListResult, error) {
+	result, err, usefs := tryResolveState(h, ctx, w3c,
+		func(w3c *node.Web3goClient) (*types.CreateAccessListResult, error) {
+			return w3c.Eth.CreateAccessList(callRequest, blockNum, overrides)
+		},
+	)
+
+	metrics.Registry.RPC.Percentage("eth_createAccessList", "fullState").Mark(usefs)
+	return result, err
+}
+
 func (h *EthStateHandler) DebugTraceTransaction(
 	ctx context.Context,
 	w3c *node.Web3goClient,
@@ -247,6 +264,23 @@ func (h *EthStateHandler) TraceFilter(
 	})
 
 	metrics.Registry.RPC.Percentage("trace_filter", "fullState").Mark(usefs)
+	return result, err
+}
+
+func (h *EthStateHandler) TraceCall(
+	ctx context.Context,
+	w3c *node.Web3goClient,
+	callRequest types.CallRequest,
+	options types.TraceOptions,
+	blockNum *types.BlockNumberOrHash,
+) (types.TraceResults, error) {
+	result, err, usefs := tryResolveState(h, ctx, w3c,
+		func(w3c *node.Web3goClient) (types.TraceResults, error) {
+			return w3c.Trace.Call(callRequest, options, blockNum)
+		},
+	)
+
+	metrics.Registry.RPC.Percentage("trace_call", "fullState").Mark(usefs)
 	return result, err
 }
 


### PR DESCRIPTION
## What changed

- Upgrade `github.com/openweb3/web3go` from the pre-release pseudo-version to the official `v0.3.5` release.
- Add the eSpace `eth_createAccessList` RPC proxy.
- Add the Parity-style eSpace `trace_call` RPC proxy.
- Route both state-dependent methods through the existing full-state fallback path and record full-state usage metrics.

## Why

Conflux Rust v3.1.0 introduces `eth_createAccessList` and Parity-style `trace_call` for eSpace. Confura needs the matching web3go SDK release and proxy handlers so clients can access these node capabilities through Confura.

## Impact

Clients can call the two new eSpace RPC methods through the existing `eth` and `trace` namespaces. Existing trace namespace exposure settings remain unchanged.

## Validation

- `go mod verify`
- `go test ./...`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/407)
<!-- Reviewable:end -->
