### PR TITLE
fix web3pay billing authentication

### DIFF
--- a/util/rpc/handlers/vip.go
+++ b/util/rpc/handlers/vip.go
@@ -70,26 +70,34 @@ func VipStatusFromContext(ctx context.Context) (*VipStatus, bool) {
 }
 
 func GetVipStatusBySubscriptionStatus(vss *web3pay.VipSubscriptionStatus) (*VipStatus, bool) {
-	vi, err := vss.GetVipInfo()
-	if err != nil {
+	if vss == nil {
 		return nil, false
 	}
 
-	expiredAt := time.Unix(vi.ExpireAt.Int64(), 0)
-	return &VipStatus{
-		ID:       vi.Account.String(),
-		Tier:     GetVipTierBySubscription(vi),
-		ExpireAt: &expiredAt,
-	}, true
+	vi, err := vss.GetVipInfo()
+	if err != nil || vi == nil {
+		return nil, false
+	}
+
+	vs := &VipStatus{
+		ID:   vi.Account.String(),
+		Tier: GetVipTierBySubscription(vi),
+	}
+	if vi.ExpireAt != nil {
+		expiredAt := time.Unix(vi.ExpireAt.Int64(), 0)
+		vs.ExpireAt = &expiredAt
+	}
+
+	return vs, true
 }
 
 func GetVipStatusByBillingStatus(bs *web3pay.BillingStatus) (*VipStatus, bool) {
-	if bs.Success() {
-		vs := &VipStatus{Tier: VipTierBilling, ID: bs.Receipt.Customer.String()}
-		return vs, true
+	if bs == nil || !bs.Success() || bs.Receipt == nil {
+		return nil, false
 	}
 
-	return nil, false
+	vs := &VipStatus{Tier: VipTierBilling, ID: bs.Receipt.Customer.String()}
+	return vs, true
 }
 
 func GetVipTierBySubscription(vi *types.VipInfo) VipTier {

--- a/util/rpc/handlers/vip_test.go
+++ b/util/rpc/handlers/vip_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	web3pay "github.com/Conflux-Chain/web3pay-service/client/middleware"
+	"github.com/Conflux-Chain/web3pay-service/service"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVipStatusByBillingStatus(t *testing.T) {
+	customer := common.HexToAddress("0x1234")
+
+	tests := []struct {
+		name   string
+		status *web3pay.BillingStatus
+		wantOK bool
+	}{
+		{
+			name: "success",
+			status: web3pay.NewBillingStatusWithReceipt("api-key", &service.BillingReceipt{
+				Customer: customer,
+			}),
+			wantOK: true,
+		},
+		{
+			name:   "billing failed",
+			status: web3pay.NewBillingStatusWithError("api-key", errors.New("billing failed")),
+		},
+		{
+			name:   "receipt missing",
+			status: web3pay.NewBillingStatusWithReceipt("api-key", nil),
+		},
+		{
+			name: "status missing",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, ok := GetVipStatusByBillingStatus(test.status)
+			require.Equal(t, test.wantOK, ok)
+			if !test.wantOK {
+				require.Nil(t, status)
+				return
+			}
+
+			require.Equal(t, VipTier(VipTierBilling), status.Tier)
+			require.Equal(t, customer.String(), status.ID)
+			require.Nil(t, status.ExpireAt)
+		})
+	}
+}

--- a/util/rpc/middlewares/auth.go
+++ b/util/rpc/middlewares/auth.go
@@ -61,15 +61,7 @@ func Authenticate(next rpc.HandleCallMsgFunc) rpc.HandleCallMsgFunc {
 func resolveAuthID(ctx context.Context) (string, error) {
 	// Web3Pay VIP user
 	if vs, ok := handlers.VipStatusFromContext(ctx); ok {
-		if vs.Tier == handlers.VipTierNone {
-			return "", errInvalidApiKey
-		}
-
-		if vs.ExpireAt.Before(time.Now()) {
-			return "", errApiKeyExpired
-		}
-
-		return vs.ID, nil
+		return resolveVipStatus(vs)
 	}
 
 	// SVIP user
@@ -78,4 +70,22 @@ func resolveAuthID(ctx context.Context) (string, error) {
 	}
 
 	return "", errInvalidApiKey
+}
+
+func resolveVipStatus(vs *handlers.VipStatus) (string, error) {
+	if vs == nil || vs.Tier == handlers.VipTierNone {
+		return "", errInvalidApiKey
+	}
+
+	if vs.Tier != handlers.VipTierBilling {
+		if vs.ExpireAt == nil {
+			return "", errInvalidApiKey
+		}
+
+		if vs.ExpireAt.Before(time.Now()) {
+			return "", errApiKeyExpired
+		}
+	}
+
+	return vs.ID, nil
 }

--- a/util/rpc/middlewares/auth_test.go
+++ b/util/rpc/middlewares/auth_test.go
@@ -1,0 +1,177 @@
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/Conflux-Chain/confura/util/rpc/handlers"
+	web3pay "github.com/Conflux-Chain/web3pay-service/client/middleware"
+	"github.com/Conflux-Chain/web3pay-service/contract"
+	"github.com/Conflux-Chain/web3pay-service/service"
+	web3paytypes "github.com/Conflux-Chain/web3pay-service/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/openweb3/go-rpc-provider"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthenticateBillingWithNilExpireAt(t *testing.T) {
+	customer := common.HexToAddress("0x1234")
+	billingStatus := web3pay.NewBillingStatusWithReceipt("api-key", &service.BillingReceipt{
+		Customer: customer,
+	})
+	ctx := context.WithValue(context.Background(), web3pay.CtxKeyBillingStatus, billingStatus)
+	ctx = context.WithValue(ctx, handlers.CtxKeyAccessToken, "12345678901234567890")
+
+	nextCalled := false
+	next := func(ctx context.Context, msg *rpc.JsonRpcMessage) *rpc.JsonRpcMessage {
+		nextCalled = true
+		authID, ok := handlers.GetAuthIdFromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, customer.String(), authID)
+		return msg
+	}
+
+	msg := &rpc.JsonRpcMessage{Version: "2.0", ID: []byte("1"), Method: "test_method"}
+	resp := Authenticate(next)(ctx, msg)
+
+	require.Same(t, msg, resp)
+	require.True(t, nextCalled)
+}
+
+func TestAuthenticateRejectsInvalidBillingStatuses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *web3pay.BillingStatus
+	}{
+		{
+			name:   "billing failed",
+			status: web3pay.NewBillingStatusWithError("api-key", errors.New("billing failed")),
+		},
+		{
+			name:   "receipt missing",
+			status: web3pay.NewBillingStatusWithReceipt("api-key", nil),
+		},
+		{
+			name:   "status missing",
+			status: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), web3pay.CtxKeyBillingStatus, test.status)
+			ctx = context.WithValue(ctx, handlers.CtxKeyAccessToken, "12345678901234567890")
+			nextCalled := false
+			next := func(ctx context.Context, msg *rpc.JsonRpcMessage) *rpc.JsonRpcMessage {
+				nextCalled = true
+				return msg
+			}
+
+			msg := &rpc.JsonRpcMessage{Version: "2.0", ID: []byte("1"), Method: "test_method"}
+			resp := Authenticate(next)(ctx, msg)
+
+			require.NotNil(t, resp.Error)
+			require.Equal(t, errInvalidApiKey.Error(), resp.Error.Error())
+			require.False(t, nextCalled)
+		})
+	}
+}
+
+func TestResolveAuthIDByTier(t *testing.T) {
+	customer := common.HexToAddress("0x1234")
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+
+	tests := []struct {
+		name    string
+		status  *handlers.VipStatus
+		wantID  string
+		wantErr error
+	}{
+		{
+			name:   "billing ignores missing expiration",
+			status: &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierBilling},
+			wantID: customer.String(),
+		},
+		{
+			name:   "billing ignores expiration value",
+			status: &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierBilling, ExpireAt: &past},
+			wantID: customer.String(),
+		},
+		{
+			name:   "subscription active",
+			status: &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierSubscription1, ExpireAt: &future},
+			wantID: customer.String(),
+		},
+		{
+			name:    "subscription expired",
+			status:  &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierSubscription1, ExpireAt: &past},
+			wantErr: errApiKeyExpired,
+		},
+		{
+			name:    "subscription expiration missing",
+			status:  &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierSubscription1},
+			wantErr: errInvalidApiKey,
+		},
+		{
+			name:    "tier none",
+			status:  &handlers.VipStatus{ID: customer.String(), Tier: handlers.VipTierNone},
+			wantErr: errInvalidApiKey,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, err := resolveVipStatus(test.status)
+			require.ErrorIs(t, err, test.wantErr)
+			require.Equal(t, test.wantID, id)
+		})
+	}
+}
+
+func TestResolveAuthIDSubscriptionStatuses(t *testing.T) {
+	customer := common.HexToAddress("0x5678")
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+
+	tests := []struct {
+		name    string
+		expires *time.Time
+		tier    string
+		wantID  string
+		wantErr error
+	}{
+		{name: "active", expires: &future, tier: "1", wantID: customer.String()},
+		{name: "expired", expires: &past, tier: "1", wantErr: errApiKeyExpired},
+		{name: "expiration missing", tier: "1", wantErr: errInvalidApiKey},
+		{name: "tier none", expires: &future, tier: "0", wantErr: errInvalidApiKey},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var expireAt *big.Int
+			if test.expires != nil {
+				expireAt = big.NewInt(test.expires.Unix())
+			}
+			vipInfo := &web3paytypes.VipInfo{
+				ICardTrackerVipInfo: contract.ICardTrackerVipInfo{
+					ExpireAt: expireAt,
+					Props: contract.ICardTemplateProps{
+						Keys:   []string{handlers.VipSubPropTierKey},
+						Values: []string{test.tier},
+					},
+				},
+				Account: customer,
+			}
+			status := web3pay.NewVipSubscriptionStatusWithInfo("api-key", vipInfo)
+			ctx := context.WithValue(context.Background(), web3pay.CtxKeyVipSubscriptionStatus, status)
+
+			id, err := resolveAuthID(ctx)
+			require.ErrorIs(t, err, test.wantErr)
+			require.Equal(t, test.wantID, id)
+		})
+	}
+}

--- a/util/rpc/middlewares/recover.go
+++ b/util/rpc/middlewares/recover.go
@@ -2,6 +2,8 @@ package middlewares
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"runtime/debug"
 
@@ -26,8 +28,8 @@ func Recover(next rpc.HandleCallMsgFunc) rpc.HandleCallMsgFunc {
 				ipAddr, _ := handlers.GetIPAddressFromContext(ctx)
 
 				logrus.WithFields(logrus.Fields{
-					"ipAddress": ipAddr,
-					"apiToken":  apiToken,
+					"ipAddress":           ipAddr,
+					"apiTokenFingerprint": accessTokenFingerprint(apiToken),
 				}).Info("RPC middleware panic with request context")
 
 				// alert error message
@@ -43,6 +45,15 @@ func Recover(next rpc.HandleCallMsgFunc) rpc.HandleCallMsgFunc {
 
 		return next(ctx, msg)
 	}
+}
+
+func accessTokenFingerprint(apiToken string) string {
+	if apiToken == "" {
+		return ""
+	}
+
+	sum := sha256.Sum256([]byte(apiToken))
+	return hex.EncodeToString(sum[:6])
 }
 
 type humanReadableRpcMessage struct {

--- a/util/rpc/middlewares/recover_test.go
+++ b/util/rpc/middlewares/recover_test.go
@@ -1,0 +1,39 @@
+package middlewares
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/Conflux-Chain/confura/util/rpc/handlers"
+	"github.com/openweb3/go-rpc-provider"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverCatchesPanicWithoutLoggingAccessToken(t *testing.T) {
+	const accessToken = "secretPaidAccessToken1234567890"
+
+	logger := logrus.StandardLogger()
+	originalOutput := logger.Out
+	var logs bytes.Buffer
+	logger.SetOutput(&logs)
+	t.Cleanup(func() {
+		logger.SetOutput(originalOutput)
+	})
+
+	ctx := context.WithValue(context.Background(), handlers.CtxKeyAccessToken, accessToken)
+	ctx = context.WithValue(ctx, handlers.CtxKeyRealIP, "192.0.2.1")
+	msg := &rpc.JsonRpcMessage{Version: "2.0", ID: []byte("1"), Method: "test_method"}
+	next := func(context.Context, *rpc.JsonRpcMessage) *rpc.JsonRpcMessage {
+		panic("unexpected middleware panic")
+	}
+
+	resp := Recover(next)(ctx, msg)
+
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, errMiddlewareCrashed.Error(), resp.Error.Error())
+	require.NotContains(t, logs.String(), accessToken)
+	require.Contains(t, logs.String(), accessTokenFingerprint(accessToken))
+}


### PR DESCRIPTION
## Summary

- handle Web3Pay billing VIP status without requiring a subscription expiration time
- fail closed for nil, failed, or receipt-less billing statuses instead of panicking
- preserve subscription expiration behavior while rejecting incomplete subscription data
- replace plaintext access tokens in panic recovery logs with a short SHA-256 fingerprint
- add regression coverage for billing, subscription, and middleware recovery scenarios

## Root cause

The authentication middleware applied the subscription expiration check to every VIP tier. Successful per-request billing statuses intentionally have no `ExpireAt`, so authentication dereferenced a nil pointer. The billing status conversion also treated a successful status with a nil receipt as usable and dereferenced `Receipt.Customer`.

## Impact

Successful billing requests continue to use the receipt customer address as the authentication ID, without requiring an artificial expiration time. Invalid or incomplete payment state now returns an invalid API key response instead of crashing the RPC middleware. Subscription expiration semantics are unchanged.

## Validation

- `go test ./util/rpc/handlers ./util/rpc/middlewares -count=1`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/408)
<!-- Reviewable:end -->
