### PR TITLE
fix atomic reorg version update

### DIFF
--- a/store/mysql/store_conf.go
+++ b/store/mysql/store_conf.go
@@ -102,16 +102,17 @@ func (cs *confStore) GetReorgVersion() (int, error) {
 	return strconv.Atoi(result.Value)
 }
 
-// thread unsafe
 func (cs *confStore) createOrUpdateReorgVersion(dbTx *gorm.DB) error {
-	version, err := cs.GetReorgVersion()
-	if err != nil {
-		return err
-	}
-
-	newVersion := strconv.Itoa(version + 1)
-
-	return cs.StoreConfig(MysqlConfKeyReorgVersion, newVersion)
+	return dbTx.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "name"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"value":      gorm.Expr("CAST(value AS UNSIGNED) + 1"),
+			"updated_at": gorm.Expr("CURRENT_TIMESTAMP"),
+		}),
+	}).Create(&conf{
+		Name:  MysqlConfKeyReorgVersion,
+		Value: "1",
+	}).Error
 }
 
 // access control config

--- a/store/mysql/store_conf_test.go
+++ b/store/mysql/store_conf_test.go
@@ -1,0 +1,40 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCreateOrUpdateReorgVersionUsesTransaction(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&conf{}))
+
+	store := newConfStore(db)
+	dbTx := db.Begin()
+	require.NoError(t, dbTx.Error)
+	require.NoError(t, store.createOrUpdateReorgVersion(dbTx))
+	require.NoError(t, dbTx.Rollback().Error)
+
+	version, err := store.GetReorgVersion()
+	require.NoError(t, err)
+	assert.Zero(t, version)
+}
+
+func TestCreateOrUpdateReorgVersionAtomicallyIncrements(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&conf{}))
+
+	store := newConfStore(db)
+	require.NoError(t, store.createOrUpdateReorgVersion(db))
+	require.NoError(t, store.createOrUpdateReorgVersion(db))
+
+	version, err := store.GetReorgVersion()
+	require.NoError(t, err)
+	assert.Equal(t, 2, version)
+}


### PR DESCRIPTION
## What changed

- use the transaction passed to `createOrUpdateReorgVersion`
- replace the read-then-write sequence with a single atomic upsert
- initialize the reorg version to `1` and increment the stored value in the database on conflicts
- add regression tests for transaction rollback and repeated increments

## Why

The previous implementation accepted a transaction but read and wrote through `cs.db`. This allowed the version update to commit independently from the reorg transaction. It also performed a non-atomic read-modify-write, so concurrent updates could overwrite each other.

## Impact

Reorg version changes now share the same commit or rollback boundary as the reorg operation, and concurrent increments no longer lose updates.

## Validation

- `go test ./store/mysql -count=1`
- `git diff --cached --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/409)
<!-- Reviewable:end -->
