### PR TITLE
Fix big log migration query race

### DIFF
--- a/store/mysql/store.go
+++ b/store/mysql/store.go
@@ -351,129 +351,29 @@ func (ms *MysqlStore[T]) GetLogs(ctx context.Context, storeFilter store.LogFilte
 }
 
 func (ms *MysqlStore[T]) getTopicLogs(ctx context.Context, topics []string, storeFilter store.LogFilter) ([]*store.Log, error) {
-	var result []*store.Log
-
-	for _, topic := range topics {
-		// convert topic hash to id
-		tid, exists, err := ms.ts.GetID(topic)
-		if err != nil {
-			return nil, errors.WithMessage(err, "failed to get topic id")
-		}
-
-		if !exists {
-			continue
-		}
-
-		// check if the topic is a big topic or not
-		isBigTopic, err := ms.btls.IsBigTopic(tid)
-		if err != nil {
-			return nil, err
-		}
-
-		// if the topic is a big topic, find the event logs from separate table.
-		if isBigTopic {
-			logs, err := ms.btls.GetTopicLogs(ctx, tid, topic, storeFilter)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, logs...)
-
-			// check log count
-			if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-				return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, false)
-			}
-
-			continue
-		}
-
-		// check timeout before query
-		select {
-		case <-ctx.Done():
-			return nil, store.ErrGetLogsTimeout
-		default:
-		}
-
-		// query from topic indexed logs
-		logs, err := ms.tils.GetTopicIndexedLogs(ctx, tid, topic, storeFilter)
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, logs...)
-
-		// check log count
-		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, false)
-		}
+	reader := optimisticMigrationLogReader{
+		source:    topicMigrationLogSource[T]{store: ms},
+		resolveID: ms.resolveTopicLogID,
 	}
-
-	// merge && sort log result
-	sort.Sort(store.LogSlice(result))
-	return result, nil
+	return reader.read(ctx, topics, storeFilter)
 }
 
 func (ms *MysqlStore[T]) getContractLogs(ctx context.Context, contracts []string, storeFilter store.LogFilter) ([]*store.Log, error) {
-	var result []*store.Log
-
-	for _, addr := range contracts {
-		// convert contract address to id
-		cid, exists, err := ms.cs.GetContractIdByAddress(addr)
-		if err != nil {
-			return nil, errors.WithMessage(err, "failed to get contract id")
-		}
-
-		if !exists {
-			continue
-		}
-
-		// check if the contract is a big contract or not
-		isBigContract, err := ms.bcls.IsBigContract(cid)
-		if err != nil {
-			return nil, err
-		}
-
-		// if the contract is a big contract, find the event logs from separate table.
-		if isBigContract {
-			logs, err := ms.bcls.GetContractLogs(ctx, cid, storeFilter)
-			if err != nil {
-				return nil, err
-			}
-
-			result = append(result, logs...)
-
-			// check log count
-			if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-				return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, false)
-			}
-
-			continue
-		}
-
-		// check timeout before query
-		select {
-		case <-ctx.Done():
-			return nil, store.ErrGetLogsTimeout
-		default:
-		}
-
-		// query from address indexed logs
-		logs, err := ms.ails.GetAddressIndexedLogs(ctx, cid, addr, storeFilter)
-		if err != nil {
-			return nil, err
-		}
-
-		result = append(result, logs...)
-
-		// check log count
-		if store.IsBoundChecksEnabled(ctx) && len(result) > int(store.MaxLogLimit) {
-			return nil, newSuggestedFilterResultSetTooLargeError(&storeFilter, result, false)
-		}
+	reader := optimisticMigrationLogReader{
+		source:    contractMigrationLogSource[T]{store: ms},
+		resolveID: ms.resolveContractLogID,
 	}
+	return reader.read(ctx, contracts, storeFilter)
+}
 
-	// merge && sort log result
-	sort.Sort(store.LogSlice(result))
-	return result, nil
+func (ms *MysqlStore[T]) resolveContractLogID(address string) (uint64, bool, error) {
+	id, exists, err := ms.cs.GetContractIdByAddress(address)
+	return id, exists, errors.WithMessage(err, "failed to get contract id")
+}
+
+func (ms *MysqlStore[T]) resolveTopicLogID(topic string) (uint64, bool, error) {
+	id, exists, err := ms.ts.GetID(topic)
+	return id, exists, errors.WithMessage(err, "failed to get topic id")
 }
 
 // Prune prune data from db store.

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -363,15 +363,16 @@ func (bcls *bigContractLogStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error
 	return nil
 }
 
-// IsBigContract check if the contract is big contract or not.
-func (bcls *bigContractLogStore[T]) IsBigContract(cid uint64) (bool, error) {
+// IsMigrationCompleted reports whether the contract logs have been moved from
+// the address hash partition to dedicated block-number partitions.
+func (bcls *bigContractLogStore[T]) IsMigrationCompleted(cid uint64) (bool, error) {
 	contractEntity := bcls.contractEntity(cid)
 	partition, existed, err := bcls.oldestPartition(contractEntity)
 	if err != nil || !existed {
 		return false, errors.WithMessage(err, "failed to get oldest partition")
 	}
 
-	// regarded as big contract with the following two cases:
+	// The contract is regarded as migrated in the following two cases:
 	// 1. oldest partition is not the initial one;
 	// 2. oldest partition is the initial one and has data on it.
 	return !partition.IsInitial() || partition.Count > 0, nil

--- a/store/mysql/store_log_big_topic.go
+++ b/store/mysql/store_log_big_topic.go
@@ -352,14 +352,15 @@ func (btls *bigTopicLogStore[T]) Popn(dbTx *gorm.DB, epochUntil uint64) error {
 	return nil
 }
 
-// IsBigTopic check if the topic is a big topic managed by this store.
-func (btls *bigTopicLogStore[T]) IsBigTopic(tid uint64) (bool, error) {
+// IsMigrationCompleted reports whether the topic logs have been moved from
+// the topic hash partition to dedicated block-number partitions.
+func (btls *bigTopicLogStore[T]) IsMigrationCompleted(tid uint64) (bool, error) {
 	partition, existed, err := btls.oldestPartition(btls.topicEntity(tid))
 	if err != nil || !existed {
 		return false, errors.WithMessage(err, "failed to get oldest partition")
 	}
 
-	// regarded as big topic with the following two cases:
+	// The topic is regarded as migrated in the following two cases:
 	// 1. oldest partition is not the initial one;
 	// 2. oldest partition is the initial one and has data on it.
 	return !partition.IsInitial() || partition.Count > 0, nil

--- a/store/mysql/store_log_migration_reader.go
+++ b/store/mysql/store_log_migration_reader.go
@@ -1,0 +1,144 @@
+package mysql
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Conflux-Chain/confura/store"
+)
+
+// migrationLogSource provides the storage operations required by the
+// optimistic migration read protocol. It does not own retry or page semantics.
+type migrationLogSource interface {
+	isMigrationCompleted(id uint64) (bool, error)
+	querySharedPartition(
+		ctx context.Context, id uint64, value string, filter store.LogFilter,
+	) ([]*store.Log, error)
+	queryDedicatedPartitions(
+		ctx context.Context, id uint64, value string, filter store.LogFilter,
+	) ([]*store.Log, error)
+}
+
+type contractMigrationLogSource[T store.ChainData] struct {
+	store *MysqlStore[T]
+}
+
+func (source contractMigrationLogSource[T]) isMigrationCompleted(id uint64) (bool, error) {
+	return source.store.bcls.IsMigrationCompleted(id)
+}
+
+func (source contractMigrationLogSource[T]) querySharedPartition(
+	ctx context.Context, id uint64, address string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	return source.store.ails.GetAddressIndexedLogs(ctx, id, address, filter)
+}
+
+func (source contractMigrationLogSource[T]) queryDedicatedPartitions(
+	ctx context.Context, id uint64, _ string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	return source.store.bcls.GetContractLogs(ctx, id, filter)
+}
+
+type topicMigrationLogSource[T store.ChainData] struct {
+	store *MysqlStore[T]
+}
+
+func (source topicMigrationLogSource[T]) isMigrationCompleted(id uint64) (bool, error) {
+	return source.store.btls.IsMigrationCompleted(id)
+}
+
+func (source topicMigrationLogSource[T]) querySharedPartition(
+	ctx context.Context, id uint64, topic string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	return source.store.tils.GetTopicIndexedLogs(ctx, id, topic, filter)
+}
+
+func (source topicMigrationLogSource[T]) queryDedicatedPartitions(
+	ctx context.Context, id uint64, topic string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	return source.store.btls.GetTopicLogs(ctx, id, topic, filter)
+}
+
+// optimisticMigrationLogReader owns the protocol for reading logs that may be
+// moved atomically from a shared partition to dedicated partitions.
+type optimisticMigrationLogReader struct {
+	source    migrationLogSource
+	resolveID func(value string) (uint64, bool, error)
+}
+
+func (reader optimisticMigrationLogReader) read(
+	ctx context.Context, values []string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	var logs []*store.Log
+
+	for _, value := range values {
+		if err := checkGetLogsContext(ctx); err != nil {
+			return nil, err
+		}
+
+		id, exists, err := reader.resolveID(value)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+
+		perLogs, err := reader.readEach(ctx, id, value, filter)
+		if err != nil {
+			return nil, err
+		}
+
+		logs = append(logs, perLogs...)
+		if store.IsBoundChecksEnabled(ctx) && len(logs) > int(store.MaxLogLimit) {
+			return nil, newSuggestedFilterResultSetTooLargeError(&filter, logs, false)
+		}
+	}
+
+	sort.Sort(store.LogSlice(logs))
+	return logs, nil
+}
+
+func (reader optimisticMigrationLogReader) readEach(
+	ctx context.Context, id uint64, value string, filter store.LogFilter,
+) ([]*store.Log, error) {
+	for {
+		if err := checkGetLogsContext(ctx); err != nil {
+			return nil, err
+		}
+
+		migrationCompleted, err := reader.source.isMigrationCompleted(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if migrationCompleted {
+			// A completed migration is authoritative and never moves back to the
+			// shared partition, so this path needs no optimistic validation.
+			return reader.source.queryDedicatedPartitions(ctx, id, value, filter)
+		}
+
+		logs, queryErr := reader.source.querySharedPartition(ctx, id, value, filter)
+
+		// Validate the optimistic shared-partition read. Migration completion
+		// invalidates this value, including a shared-query error.
+		migrationCompleted, validationErr := reader.source.isMigrationCompleted(id)
+		if validationErr != nil {
+			return nil, validationErr
+		}
+		if migrationCompleted {
+			continue
+		}
+
+		return logs, queryErr
+	}
+}
+
+func checkGetLogsContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return store.ErrGetLogsTimeout
+	default:
+		return nil
+	}
+}

--- a/store/mysql/store_log_migration_reader_test.go
+++ b/store/mysql/store_log_migration_reader_test.go
@@ -1,0 +1,155 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Conflux-Chain/confura/store"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type migrationAwareLogSource struct {
+	migrationCompleted map[uint64]bool
+	migratingID        uint64
+	stateChecks        map[uint64]int
+	sharedQueries      map[uint64]int
+	dedicatedQueries   map[uint64]int
+	sharedLogs         map[uint64][]*store.Log
+	dedicatedLogs      map[uint64][]*store.Log
+	sharedErr          error
+}
+
+func (source *migrationAwareLogSource) isMigrationCompleted(id uint64) (bool, error) {
+	source.stateChecks[id]++
+	if id == source.migratingID && source.stateChecks[id] == 2 {
+		source.migrationCompleted[id] = true
+	}
+	return source.migrationCompleted[id], nil
+}
+
+func (source *migrationAwareLogSource) querySharedPartition(
+	_ context.Context, id uint64, _ string, _ store.LogFilter,
+) ([]*store.Log, error) {
+	source.sharedQueries[id]++
+	return source.sharedLogs[id], source.sharedErr
+}
+
+func (source *migrationAwareLogSource) queryDedicatedPartitions(
+	_ context.Context, id uint64, _ string, _ store.LogFilter,
+) ([]*store.Log, error) {
+	source.dedicatedQueries[id]++
+	return source.dedicatedLogs[id], nil
+}
+
+func TestOptimisticMigrationLogReaderRetriesOnlyInvalidatedValue(t *testing.T) {
+	source := &migrationAwareLogSource{
+		migrationCompleted: make(map[uint64]bool),
+		migratingID:        2,
+		stateChecks:        make(map[uint64]int),
+		sharedQueries:      make(map[uint64]int),
+		dedicatedQueries:   make(map[uint64]int),
+		sharedLogs: map[uint64][]*store.Log{
+			1: {{BlockNumber: 30}},
+			// The shared partition is empty after the migration commits.
+			2: nil,
+		},
+		dedicatedLogs: map[uint64][]*store.Log{
+			2: {{BlockNumber: 20}},
+		},
+	}
+	reader := optimisticMigrationLogReader{source: source, resolveID: resolveTestLogID}
+
+	logs, err := reader.read(context.Background(), []string{"first", "migrating"}, store.LogFilter{})
+	require.NoError(t, err)
+	require.Len(t, logs, 2)
+	assert.Equal(t, uint64(20), logs[0].BlockNumber)
+	assert.Equal(t, uint64(30), logs[1].BlockNumber)
+
+	// The stable first value is retained while only the value invalidated by
+	// migration is retried against its dedicated partitions.
+	assert.Equal(t, 1, source.sharedQueries[1])
+	assert.Equal(t, 1, source.sharedQueries[2])
+	assert.Equal(t, 1, source.dedicatedQueries[2])
+}
+
+func TestOptimisticMigrationLogReaderDoesNotRecheckCompletedMigration(t *testing.T) {
+	source := &migrationAwareLogSource{
+		migrationCompleted: map[uint64]bool{1: true},
+		stateChecks:        make(map[uint64]int),
+		sharedQueries:      make(map[uint64]int),
+		dedicatedQueries:   make(map[uint64]int),
+		dedicatedLogs:      map[uint64][]*store.Log{1: {{BlockNumber: 20}}},
+	}
+	reader := optimisticMigrationLogReader{source: source, resolveID: resolveTestLogID}
+
+	logs, err := reader.read(context.Background(), []string{"migrated"}, store.LogFilter{})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, 1, source.stateChecks[1])
+	assert.Zero(t, source.sharedQueries[1])
+	assert.Equal(t, 1, source.dedicatedQueries[1])
+}
+
+func TestOptimisticMigrationLogReaderDiscardsInvalidatedSharedQueryError(t *testing.T) {
+	sharedErr := errors.New("shared partition query failed")
+	source := &migrationAwareLogSource{
+		migrationCompleted: make(map[uint64]bool),
+		migratingID:        1,
+		stateChecks:        make(map[uint64]int),
+		sharedQueries:      make(map[uint64]int),
+		dedicatedQueries:   make(map[uint64]int),
+		dedicatedLogs:      map[uint64][]*store.Log{1: {{BlockNumber: 20}}},
+		sharedErr:          sharedErr,
+	}
+	reader := optimisticMigrationLogReader{source: source, resolveID: resolveTestLogID}
+
+	logs, err := reader.read(context.Background(), []string{"first"}, store.LogFilter{})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, 1, source.sharedQueries[1])
+	assert.Equal(t, 1, source.dedicatedQueries[1])
+}
+
+func TestOptimisticMigrationLogReaderReturnsStableSharedQueryError(t *testing.T) {
+	sharedErr := errors.New("shared partition query failed")
+	source := &migrationAwareLogSource{
+		migrationCompleted: make(map[uint64]bool),
+		stateChecks:        make(map[uint64]int),
+		sharedQueries:      make(map[uint64]int),
+		dedicatedQueries:   make(map[uint64]int),
+		sharedErr:          sharedErr,
+	}
+	reader := optimisticMigrationLogReader{source: source, resolveID: resolveTestLogID}
+
+	logs, err := reader.read(context.Background(), []string{"first"}, store.LogFilter{})
+	assert.Nil(t, logs)
+	assert.ErrorIs(t, err, sharedErr)
+	assert.Equal(t, 2, source.stateChecks[1])
+	assert.Equal(t, 1, source.sharedQueries[1])
+	assert.Zero(t, source.dedicatedQueries[1])
+}
+
+func TestOptimisticMigrationLogReaderStopsWhenContextIsDone(t *testing.T) {
+	source := &migrationAwareLogSource{
+		migrationCompleted: make(map[uint64]bool),
+		stateChecks:        make(map[uint64]int),
+		sharedQueries:      make(map[uint64]int),
+		dedicatedQueries:   make(map[uint64]int),
+	}
+	reader := optimisticMigrationLogReader{source: source, resolveID: resolveTestLogID}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	logs, err := reader.read(ctx, []string{"first"}, store.LogFilter{})
+	assert.Nil(t, logs)
+	assert.ErrorIs(t, err, store.ErrGetLogsTimeout)
+	assert.Empty(t, source.stateChecks)
+}
+
+func resolveTestLogID(value string) (uint64, bool, error) {
+	ids := map[string]uint64{"first": 1, "migrating": 2, "migrated": 1}
+	id, exists := ids[value]
+	return id, exists, nil
+}


### PR DESCRIPTION
## What changed

- add an optimistic migration log reader shared by contract-address and topic queries
- distinguish shared hash partitions from dedicated block-number partitions
- recheck migration state after shared-partition reads and retry only the invalidated address/topic
- avoid redundant validation when migration was already complete
- clarify migration-completion state naming for big contract and topic stores

## Why

The migration transaction atomically inserts logs into dedicated partitions, deletes them from the shared partition, and updates partition metadata. A concurrent RPC could read the pre-migration routing state, then query the shared partition after the transaction committed, returning an empty result.

The reader now treats the shared-partition query as an optimistic read. If migration completes during that read, its result and any transient query error are discarded and only that contract/topic is retried against the authoritative dedicated partitions.

## Impact

Queries no longer lose logs when they overlap a big contract/topic migration. Requests containing many addresses or topics retain already validated results and do not restart from the first item when a later item is invalidated.

## Validation

- `go test ./...`
- `go test ./store/...`
- `go vet ./store/...`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/410)
<!-- Reviewable:end -->
