### PR TITLE
add composite log indexes for `scanLogs` rpc

### DIFF
--- a/store/mysql/store_log.go
+++ b/store/mysql/store_log.go
@@ -19,13 +19,13 @@ const (
 
 type log struct {
 	ID          uint64
-	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn"`
+	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn_li,priority:1"`
 	Epoch       uint64 `gorm:"not null"`
 	Topic0      string `gorm:"size:66;not null"`
 	Topic1      string `gorm:"size:66"`
 	Topic2      string `gorm:"size:66"`
 	Topic3      string `gorm:"size:66"`
-	LogIndex    uint64 `gorm:"not null"`
+	LogIndex    uint64 `gorm:"not null;index:idx_bn_li,priority:2"`
 	Extra       []byte `gorm:"type:mediumText"` // extension json field
 }
 

--- a/store/mysql/store_log_addr.go
+++ b/store/mysql/store_log_addr.go
@@ -15,14 +15,14 @@ import (
 
 type AddressIndexedLog struct {
 	ID          uint64
-	ContractID  uint64 `gorm:"column:cid;not null;index:idx_cid_bn,priority:1;index:idx_cid_tid_bn,priority:1"`
-	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_cid_bn,priority:2;index:idx_cid_tid_bn,priority:3"`
+	ContractID  uint64 `gorm:"column:cid;not null;index:idx_cid_bn_li,priority:1;index:idx_cid_tid_bn_li,priority:1"`
+	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_cid_bn_li,priority:2;index:idx_cid_tid_bn_li,priority:3"`
 	Epoch       uint64 `gorm:"not null;index"` // to support pop logs when reorg
-	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_cid_tid_bn,priority:2"`
+	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_cid_tid_bn_li,priority:2"`
 	Topic1      string `gorm:"size:66"`
 	Topic2      string `gorm:"size:66"`
 	Topic3      string `gorm:"size:66"`
-	LogIndex    uint64 `gorm:"not null"`
+	LogIndex    uint64 `gorm:"not null;index:idx_cid_bn_li,priority:3;index:idx_cid_tid_bn_li,priority:4"`
 	Extra       []byte `gorm:"type:mediumText"` // extension json field
 }
 

--- a/store/mysql/store_log_big_contract.go
+++ b/store/mysql/store_log_big_contract.go
@@ -24,13 +24,13 @@ const (
 type contractLog struct {
 	ID          uint64
 	ContractID  uint64 `gorm:"-"`
-	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn;index:idx_tid_bn,priority:2"`
+	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn_li,priority:1;index:idx_tid_bn_li,priority:2"`
 	Epoch       uint64 `gorm:"not null"`
-	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_tid_bn,priority:1"`
+	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_tid_bn_li,priority:1"`
 	Topic1      string `gorm:"size:66"`
 	Topic2      string `gorm:"size:66"`
 	Topic3      string `gorm:"size:66"`
-	LogIndex    uint64 `gorm:"not null"`
+	LogIndex    uint64 `gorm:"not null;index:idx_bn_li,priority:2;index:idx_tid_bn_li,priority:3"`
 	Extra       []byte `gorm:"type:mediumText"` // extension json field
 }
 

--- a/store/mysql/store_log_big_topic.go
+++ b/store/mysql/store_log_big_topic.go
@@ -20,13 +20,13 @@ const (
 // topicLog represents a log entry stored in a dedicated topic table.
 type topicLog struct {
 	ID          uint64
-	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn"`
+	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_bn_li,priority:1"`
 	Epoch       uint64 `gorm:"not null"`
 	Topic0ID    uint64 `gorm:"-"` // topic0 id (not persisted, used for table naming)
 	Topic1      string `gorm:"size:66"`
 	Topic2      string `gorm:"size:66"`
 	Topic3      string `gorm:"size:66"`
-	LogIndex    uint64 `gorm:"not null"`
+	LogIndex    uint64 `gorm:"not null;index:idx_bn_li,priority:2"`
 	Extra       []byte `gorm:"type:mediumText"` // extension json field
 }
 

--- a/store/mysql/store_log_index_test.go
+++ b/store/mysql/store_log_index_test.go
@@ -1,0 +1,117 @@
+package mysql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+type sqliteIndexListRow struct {
+	Name string
+}
+
+type sqliteIndexInfoRow struct {
+	Name string
+}
+
+func TestNewLogPartitionsUseScanLogsIndexes(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      schema.Tabler
+		table      string
+		expected   map[string][]string
+		replacedBy []string
+	}{
+		{
+			name:     "universal logs",
+			model:    &log{},
+			table:    "logs_0",
+			expected: map[string][]string{"idx_bn_li": {"bn", "log_index"}},
+			replacedBy: []string{
+				"idx_bn",
+			},
+		},
+		{
+			name:  "address indexed logs",
+			model: &AddressIndexedLog{},
+			table: "addr_logs_0",
+			expected: map[string][]string{
+				"idx_cid_bn_li":     {"cid", "bn", "log_index"},
+				"idx_cid_tid_bn_li": {"cid", "tid", "bn", "log_index"},
+			},
+			replacedBy: []string{"idx_cid_bn", "idx_cid_tid_bn"},
+		},
+		{
+			name:  "topic indexed logs",
+			model: &TopicIndexedLog{},
+			table: "topic_logs_0",
+			expected: map[string][]string{
+				"idx_tid_bn_li": {"tid", "bn", "log_index"},
+			},
+			replacedBy: []string{"idx_tid_bn"},
+		},
+		{
+			name:  "dedicated contract logs",
+			model: &contractLog{ContractID: 42},
+			table: "clogs_42_0",
+			expected: map[string][]string{
+				"idx_bn_li":     {"bn", "log_index"},
+				"idx_tid_bn_li": {"tid", "bn", "log_index"},
+			},
+			replacedBy: []string{"idx_bn", "idx_tid_bn"},
+		},
+		{
+			name:  "dedicated topic logs",
+			model: &topicLog{Topic0ID: 7},
+			table: "tlogs_7_0",
+			expected: map[string][]string{
+				"idx_bn_li": {"bn", "log_index"},
+			},
+			replacedBy: []string{"idx_bn"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+			require.NoError(t, err)
+
+			created, err := (&partitionedStore{}).createPartitionedTable(db, test.model, 0)
+			require.NoError(t, err)
+			require.True(t, created)
+
+			indexes := loadSQLiteIndexes(t, db, test.table)
+			for name, columns := range test.expected {
+				require.Equal(t, columns, indexes[name], "index %s on table %s", name, test.table)
+			}
+			for _, oldName := range test.replacedBy {
+				require.NotContains(t, indexes, oldName, "old index %s on table %s", oldName, test.table)
+			}
+		})
+	}
+}
+
+func loadSQLiteIndexes(t *testing.T, db *gorm.DB, table string) map[string][]string {
+	t.Helper()
+
+	var indexRows []sqliteIndexListRow
+	require.NoError(t, db.Raw(fmt.Sprintf("PRAGMA index_list(%q)", table)).Scan(&indexRows).Error)
+
+	indexes := make(map[string][]string, len(indexRows))
+	for _, index := range indexRows {
+		var columnRows []sqliteIndexInfoRow
+		require.NoError(t, db.Raw(fmt.Sprintf("PRAGMA index_info(%q)", index.Name)).Scan(&columnRows).Error)
+
+		columns := make([]string, 0, len(columnRows))
+		for _, column := range columnRows {
+			columns = append(columns, column.Name)
+		}
+		indexes[index.Name] = columns
+	}
+
+	return indexes
+}

--- a/store/mysql/store_log_topic.go
+++ b/store/mysql/store_log_topic.go
@@ -14,13 +14,13 @@ import (
 // For high-frequency topics (e.g., Transfer) are typically stored in separate special tables.
 type TopicIndexedLog struct {
 	ID          uint64
-	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_tid_bn,priority:2"`
-	Epoch       uint64 `gorm:"not null;index"`                                  // to support pop logs when reorg
-	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_tid_bn,priority:1"` // topic0 id
+	BlockNumber uint64 `gorm:"column:bn;not null;index:idx_tid_bn_li,priority:2"`
+	Epoch       uint64 `gorm:"not null;index"`                                     // to support pop logs when reorg
+	Topic0ID    uint64 `gorm:"column:tid;not null;index:idx_tid_bn_li,priority:1"` // topic0 id
 	Topic1      string `gorm:"size:66"`
 	Topic2      string `gorm:"size:66"`
 	Topic3      string `gorm:"size:66"`
-	LogIndex    uint64 `gorm:"not null"`
+	LogIndex    uint64 `gorm:"not null;index:idx_tid_bn_li,priority:3"`
 	Extra       []byte `gorm:"type:mediumText"` // extension json field
 }
 


### PR DESCRIPTION
## Summary

- extend all log table indexes with `log_index` for deterministic keyset ordering
- remove superseded index definitions from newly created tables
- verify the physical indexes and column order for universal, address, topic, big-contract, and big-topic partitions

The one-off production DDL script is intentionally excluded from this PR and remains an operational release artifact.

## Testing

- `go test ./store/mysql -count=1`
- `go test ./... -count=1`
- MySQL 8.4.11 `plan -> add -> verify -> drop` DDL rehearsal, including idempotent reruns and forward/reverse EXPLAIN checks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/411)
<!-- Reviewable:end -->
