### PR TITLE
refactor: correct internal trace builder and partition names

### DIFF
--- a/rpc/cfxbridge/trace_builder.go
+++ b/rpc/cfxbridge/trace_builder.go
@@ -150,7 +150,7 @@ func (ttb *TransactionTraceBuilder) Append(trace, traceResult *types.LocalizedTr
 
 type BlockTraceBuilder struct {
 	txTraces []types.LocalizedTransactionTrace
-	builer   TransactionTraceBuilder
+	builder  TransactionTraceBuilder
 }
 
 func (btb *BlockTraceBuilder) Build() ([]types.LocalizedTransactionTrace, error) {
@@ -170,7 +170,7 @@ func (btb *BlockTraceBuilder) Append(trace, traceResult *types.LocalizedTrace, t
 		return nil
 	}
 
-	next, err := btb.builer.Append(trace, traceResult, traceAddress)
+	next, err := btb.builder.Append(trace, traceResult, traceAddress)
 	if err != nil || next {
 		return err
 	}
@@ -179,19 +179,19 @@ func (btb *BlockTraceBuilder) Append(trace, traceResult *types.LocalizedTrace, t
 		return err
 	}
 
-	_, err = btb.builer.Append(trace, traceResult, traceAddress)
+	_, err = btb.builder.Append(trace, traceResult, traceAddress)
 	return err
 }
 
 func (btb *BlockTraceBuilder) seal() error {
-	txTrace, ok, err := btb.builer.Build()
+	txTrace, ok, err := btb.builder.Build()
 	if err != nil {
 		return err
 	}
 
 	if ok {
 		btb.txTraces = append(btb.txTraces, *txTrace)
-		btb.builer = TransactionTraceBuilder{}
+		btb.builder = TransactionTraceBuilder{}
 	}
 
 	return nil

--- a/store/mysql/common_partition.go
+++ b/store/mysql/common_partition.go
@@ -98,11 +98,11 @@ func (mrp *mysqlRangePartitioner) addPartition(db *gorm.DB, index int, threshold
 	return db.Exec(sql).Error
 }
 
-func (mrp *mysqlRangePartitioner) removePartition(db *gorm.DB, partiton *mysqlPartition) error {
+func (mrp *mysqlRangePartitioner) removePartition(db *gorm.DB, partition *mysqlPartition) error {
 	sql := fmt.Sprintf(
 		"ALTER TABLE %v DROP PARTITION %v;",
 		mrp.tableName,
-		partiton.Name,
+		partition.Name,
 	)
 	return db.Exec(sql).Error
 }


### PR DESCRIPTION
Correct the internal `builer` field and `partiton` parameter names in the trace builder and MySQL partitioner. The rename is internal and does not change behavior or exported APIs.

Validated with `go test ./rpc/cfxbridge ./store/mysql`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/413)
<!-- Reviewable:end -->
