### PR TITLE
feat(rpc): add scan logs APIs

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -489,6 +489,13 @@ node:
 #     # Maximum block range to split log filters for full nodes
 #     maxSplitBlockRange: 1000
 
+#   # Cursor-paginated scanLogs limits
+#   scanLogs:
+#     # Maximum effective page size (must not exceed the Store log limit 10,000)
+#     maxLimit: 1000
+#     # Full node window size, in epochs for Core space and blocks for eSpace
+#     fullnodeWindowSize: 1000
+
 #   # Resource usage constraints
 #   resourceLimits:
 #     # Maximum response bytes for 'getLogs' requests (default 10MB)

--- a/rpc/cfx_api.go
+++ b/rpc/cfx_api.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 
+	cacheTypes "github.com/Conflux-Chain/confura-data-cache/types"
 	"github.com/Conflux-Chain/confura/node"
 	"github.com/Conflux-Chain/confura/rpc/handler"
 	"github.com/Conflux-Chain/confura/store"
@@ -18,8 +19,14 @@ import (
 )
 
 const (
-	rpcMethodCfxGetLogs = "cfx_getLogs"
+	rpcMethodCfxGetLogs                     = "cfx_getLogs"
+	rpcMethodCfxScanLogs                    = "cfx_scanLogs"
+	rpcMethodCfxScanLogsWithPivotAssumption = "cfx_scanLogsWithPivotAssumption"
 )
+
+func isCfxScanLogsRpcMethod(method string) bool {
+	return method == rpcMethodCfxScanLogs || method == rpcMethodCfxScanLogsWithPivotAssumption
+}
 
 var (
 	emptyEpochs             = []*types.Epoch{}
@@ -271,6 +278,54 @@ func (api *cfxAPI) Call(ctx context.Context, request types.CallRequest, epoch *t
 func (api *cfxAPI) GetLogs(ctx context.Context, fq types.LogFilter) ([]types.Log, error) {
 	cfx := GetCfxClientFromContext(ctx)
 	return api.getLogs(ctx, cfx, fq, rpcMethodCfxGetLogs)
+}
+
+func (api *cfxAPI) ScanLogs(
+	ctx context.Context,
+	req handler.CfxScanLogRequest,
+) (cacheTypes.Lazy[*handler.CfxScanLogResult], error) {
+	return api.scanLogs(ctx, req, nil, false)
+}
+
+func (api *cfxAPI) ScanLogsWithPivotAssumption(
+	ctx context.Context,
+	req handler.CfxScanLogRequest,
+	assumption *handler.CfxPivotAssumption,
+) (cacheTypes.Lazy[*handler.CfxScanLogResult], error) {
+	return api.scanLogs(ctx, req, assumption, true)
+}
+
+func (api *cfxAPI) scanLogs(
+	ctx context.Context,
+	req handler.CfxScanLogRequest,
+	assumption *handler.CfxPivotAssumption,
+	withPivotAssumption bool,
+) (cacheTypes.Lazy[*handler.CfxScanLogResult], error) {
+	if api.LogApiHandler == nil {
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessage(
+			handler.ErrScanLogsUnavailable, "api handler not configured",
+		)
+	}
+
+	if withPivotAssumption && req.Cursor != nil && assumption == nil {
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessagef(
+			handler.ErrScanLogsInvalidParams, "missing pivot assumption",
+		)
+	}
+
+	cfx := GetCfxClientFromContext(ctx)
+	params, err := handler.NormalizeCfxScanLogRequest(cfx, req, withPivotAssumption)
+	if err != nil {
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessage(err, "failed to normalize scan request")
+	}
+
+	result, err := api.LogApiHandler.ScanLogs(ctx, cfx, params, assumption)
+	if err != nil {
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, err
+	}
+
+	result.Logs = uniformCfxLogs(result.Logs)
+	return handler.EncodeScanLogsResult(result)
 }
 
 // getLogs helper method to get logs from store or fullnode.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	rpcMethodEthGetLogs = "eth_getLogs"
+	rpcMethodEthGetLogs                     = "eth_getLogs"
+	rpcMethodEthScanLogs                    = "eth_scanLogs"
+	rpcMethodEthScanLogsWithPivotAssumption = "eth_scanLogsWithPivotAssumption"
 
 	// The maximum number of percentile values to sample from each block's
 	// effective priority fees per gas in ascending order.
@@ -29,6 +31,10 @@ const (
 	// The maximum number of blocks in the requested range for fee history.
 	maxFeeHistoryBlockCnt = 1024
 )
+
+func isEthScanLogsRpcMethod(method string) bool {
+	return method == rpcMethodEthScanLogs || method == rpcMethodEthScanLogsWithPivotAssumption
+}
 
 var (
 	ethEmptyLogs = []web3Types.Log{}
@@ -498,6 +504,54 @@ func (api *ethAPI) GetAccountPendingTransactions(
 func (api *ethAPI) GetLogs(ctx context.Context, fq web3Types.FilterQuery) ([]web3Types.Log, error) {
 	w3c := GetEthClientFromContext(ctx)
 	return api.getLogs(ctx, w3c, &fq, rpcMethodEthGetLogs)
+}
+
+func (api *ethAPI) ScanLogs(
+	ctx context.Context,
+	req handler.EthScanLogRequest,
+) (cacheTypes.Lazy[*handler.EthScanLogResult], error) {
+	return api.scanLogs(ctx, req, nil, false)
+}
+
+func (api *ethAPI) ScanLogsWithPivotAssumption(
+	ctx context.Context,
+	req handler.EthScanLogRequest,
+	assumption *handler.EthPivotAssumption,
+) (cacheTypes.Lazy[*handler.EthScanLogResult], error) {
+	return api.scanLogs(ctx, req, assumption, true)
+}
+
+func (api *ethAPI) scanLogs(
+	ctx context.Context,
+	req handler.EthScanLogRequest,
+	assumption *handler.EthPivotAssumption,
+	withPivotAssumption bool,
+) (cacheTypes.Lazy[*handler.EthScanLogResult], error) {
+	if api.LogApiHandler == nil {
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessage(
+			handler.ErrScanLogsUnavailable, "api handler not configured",
+		)
+	}
+
+	if withPivotAssumption && req.Cursor != nil && assumption == nil {
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessagef(
+			handler.ErrScanLogsInvalidParams, "missing pivot assumption",
+		)
+	}
+
+	w3c := GetEthClientFromContext(ctx)
+	params, err := handler.NormalizeEthScanLogRequest(w3c.Eth, api.hardforkBlockNumber, req, withPivotAssumption)
+	if err != nil {
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessage(err, "failed to normalize scan request")
+	}
+
+	result, err := api.LogApiHandler.ScanLogs(ctx, w3c.Client.Eth, params, assumption)
+	if err != nil {
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, err
+	}
+
+	result.Logs = uniformEthLogs(result.Logs)
+	return handler.EncodeScanLogsResult(result)
 }
 
 // getLogs helper method to get logs from store or fullnode.

--- a/rpc/handler/cfx_logs.go
+++ b/rpc/handler/cfx_logs.go
@@ -37,6 +37,31 @@ func MustInitFromViper() {
 		"result body size is too large with more than %d bytes, please narrow down your filter condition",
 		maxGetLogsResponseBytes,
 	)
+
+	var scanLogs struct {
+		MaxLimit           uint64 `default:"1000"`
+		FullnodeWindowSize uint64 `default:"1000"`
+	}
+	viperutil.MustUnmarshalKey("requestControl.scanLogs", &scanLogs)
+
+	if scanLogs.MaxLimit > store.MaxLogLimit {
+		logrus.Fatalf(
+			"`scanLogs.maxLimit` is %d, but must not exceed %d",
+			scanLogs.MaxLimit, store.MaxLogLimit,
+		)
+	}
+	if scanLogs.MaxLimit < defaultScanLogsLimit {
+		logrus.Fatalf(
+			"`scanLogs.maxLimit` is %d, but must be at least the default limit %d",
+			scanLogs.MaxLimit, defaultScanLogsLimit,
+		)
+	}
+	if scanLogs.FullnodeWindowSize == 0 {
+		logrus.Fatal("`scanLogs.fullnodeWindowSize` must be greater than 0")
+	}
+
+	maxScanLogsLimit = scanLogs.MaxLimit
+	defaultScanLogsFNWindow = scanLogs.FullnodeWindowSize
 }
 
 // CfxLogsApiHandler RPC handler to get core space event logs from store or fullnode.

--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -46,7 +46,7 @@ func (f *CfxScanLogFilter) UnmarshalJSON(data []byte) error {
 	var decoded plain
 
 	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
-		return errors.WithMessage(err, "invalid core scan filter")
+		return errors.WithMessage(err, "invalid scan filter")
 	}
 	if err := validateJSONObjectFields(data, nil, []string{"epochRange", "address", "topic0"}); err != nil {
 		return err
@@ -75,7 +75,7 @@ func (r *CfxScanLogRequest) UnmarshalJSON(data []byte) error {
 	type plain CfxScanLogRequest
 	var decoded plain
 	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
-		return errors.WithMessage(err, "invalid core scan request")
+		return errors.WithMessage(err, "invalid scan request")
 	}
 	if err := validateJSONObjectFields(
 		data,
@@ -107,7 +107,7 @@ func (a *CfxPivotAssumption) UnmarshalJSON(data []byte) error {
 	type plain CfxPivotAssumption
 	var decoded plain
 	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
-		return errors.WithMessage(err, "invalid core pivot assumption")
+		return errors.WithMessage(err, "invalid pivot assumption")
 	}
 	if err := validateJSONObjectFields(
 		data,
@@ -635,23 +635,28 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
 		)
 	}
+
 	recorder := newScanLogsMetrics("cfx", req.WithPivotAssumption)
 	ctx = withScanLogsMetrics(ctx, recorder)
 	started := time.Now()
+
 	recorder.Percentage("direction/reverse", req.Reverse)
 	recorder.Histogram("limit", int64(req.Limit))
+
 	defer func() {
 		recorder.Duration("duration", started)
 		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
 		if result == nil {
 			return
 		}
+
 		recorder.Histogram("result", int64(len(result.Logs)))
 		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
 		recorder.Percentage("source/db", db && !fn)
 		recorder.Percentage("source/fn", fn && !db)
 		recorder.Percentage("source/mixed", db && fn)
 	}()
+
 	return handler.scanLogs(ctx, cfx, req, assumption)
 }
 
@@ -696,8 +701,9 @@ func (handler *CfxLogsApiHandler) scanLogs(
 			}
 			return nil, errors.WithMessage(err, "failed to build scan generation")
 		}
+
 		recordScanLogsHistogram(ctx, "plan/segments", int64(len(gen.plan.segments)))
-		recordScanLogsHistogram(ctx, "plan/cursor_owner", int64(gen.owner))
+		recordScanLogsCursorOwner(ctx, gen.owner)
 
 		// Cache lifetime is exactly this outer generation. FN-only plans do not
 		// allocate one; a cache survives inner retries but never an outer restart.
@@ -877,18 +883,19 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 		// The before summary both identifies the FN view and bounds all cursor BN
 		// lookups that may occur while building this candidate.
 		before, err := cfx.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(h))
-		markScanLogsMetric(ctx, "core/checkpoint_before")
+		markScanLogsMetric(ctx, "checkpoint_before")
 		if err != nil {
 			return nil, false, errors.WithMessage(err, "failed to get pivot block summary")
 		}
 
-		attempt, err := newCfxFNAttemptView(cfx, h, before)
+		attempt, err := newCfxFNAttemptView(
+			cfx, h, before, scanLogsMetricsFromContext(ctx),
+		)
 		if err != nil {
 			// A checkpoint without the fields needed by the algorithm cannot define
 			// a fence, so fail this node call directly.
 			return nil, false, err
 		}
-		attempt.metrics = scanLogsMetricsFromContext(ctx)
 
 		candidate, err := handler.buildCfxInnerCandidate(ctx, cfx, req, assumption, outer, attempt)
 		if err != nil {
@@ -923,7 +930,7 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 		// Eliminating ABA requires a node-provided immutable view token or atomic
 		// range RPC; JSON-RPC batch does not provide that guarantee.
 		after, err := cfx.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(h))
-		markScanLogsMetric(ctx, "core/checkpoint_after")
+		markScanLogsMetric(ctx, "checkpoint_after")
 		if err != nil {
 			return nil, false, errors.WithMessagef(err, "failed to get block summary for epoch %d", h)
 		}
@@ -1077,6 +1084,7 @@ func newCfxFNAttemptView(
 	client cfxScanClient,
 	checkpointEpoch uint64,
 	checkpointSummary *cfxtypes.BlockSummary,
+	metrics scanLogsMetricsRecorder,
 ) (*cfxFNAttemptView, error) {
 	checkpoint, err := newCfxBlockRef(checkpointSummary)
 	if err != nil {
@@ -1090,6 +1098,7 @@ func newCfxFNAttemptView(
 		pivots:          make(map[uint64]cfxBlockRef),
 		byNumber:        make(map[uint64]cfxBlockRef),
 		byHash:          make(map[cfxtypes.Hash]cfxBlockRef),
+		metrics:         metrics,
 	}
 	view.rememberPivot(checkpoint)
 	return view, nil
@@ -1108,7 +1117,7 @@ func (v *cfxFNAttemptView) rememberPivot(ref cfxBlockRef) {
 func (v *cfxFNAttemptView) pivot(epoch uint64) (cfxBlockRef, error) {
 	if ref, ok := v.pivots[epoch]; ok {
 		if v.metrics != nil {
-			v.metrics.Mark("core/pivot_cache_reuse")
+			v.metrics.Mark("pivot_cache_reuse")
 		}
 		return ref, nil
 	}
@@ -1122,7 +1131,7 @@ func (v *cfxFNAttemptView) pivot(epoch uint64) (cfxBlockRef, error) {
 
 	summary, err := v.client.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(epoch))
 	if v.metrics != nil {
-		v.metrics.Mark("core/pivot_rpc")
+		v.metrics.Mark("pivot_rpc")
 	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(
@@ -1163,7 +1172,7 @@ func (v *cfxFNAttemptView) block(number uint64) (cfxBlockRef, error) {
 
 	summary, err := v.client.GetBlockSummaryByBlockNumber(hexutil.Uint64(number))
 	if v.metrics != nil {
-		v.metrics.Mark("core/cursor_summary")
+		v.metrics.Mark("cursor_summary")
 	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(
@@ -1195,7 +1204,7 @@ func (v *cfxFNAttemptView) blockByHash(hash cfxtypes.Hash) (cfxBlockRef, error) 
 
 	summary, err := v.client.GetBlockSummaryByHash(hash)
 	if v.metrics != nil {
-		v.metrics.Mark("core/tail_position_rpc")
+		v.metrics.Mark("tail_position_rpc")
 	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(

--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -645,16 +645,14 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 
 	defer func() {
 		recorder.Duration("duration", started)
-		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
-		if result == nil {
-			return
-		}
 
-		recorder.Histogram("result", int64(len(result.Logs)))
-		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
-		recorder.Percentage("source/db", db && !fn)
-		recorder.Percentage("source/fn", fn && !db)
-		recorder.Percentage("source/mixed", db && fn)
+		if result != nil {
+			recorder.Histogram("result", int64(len(result.Logs)))
+			db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
+			recorder.Percentage("source/db", db && !fn)
+			recorder.Percentage("source/fn", fn && !db)
+			recorder.Percentage("source/mixed", db && fn)
+		}
 	}()
 
 	return handler.scanLogs(ctx, cfx, req, assumption)
@@ -808,7 +806,7 @@ func (handler *CfxLogsApiHandler) checkCfxDBAssumption(
 
 	if !equalCfxHash(cfxtypes.Hash(pivot), assumption.PivotBlockHash) {
 		return true, errors.WithMessagef(
-			ErrScanLogsAssumptionNotMet,
+			ErrScanLogsAssumptionFailure,
 			"expected pivot %s got %s for epoch %d",
 			assumption.PivotBlockHash, pivot, assumption.EpochNumber,
 		), nil
@@ -1023,7 +1021,7 @@ func (handler *CfxLogsApiHandler) buildCfxInnerCandidate(
 		}
 		if err == nil && provisionalErr == nil && !equalCfxHash(pivot.hash, assumption.PivotBlockHash) {
 			provisionalErr = newCanonicalDependentError(
-				ErrScanLogsAssumptionNotMet,
+				ErrScanLogsAssumptionFailure,
 				"expected pivot %s got %s for epoch %d",
 				assumption.PivotBlockHash, pivot.hash, assumption.EpochNumber,
 			)

--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -18,10 +19,40 @@ type CfxEpochRange struct {
 	To   *cfxtypes.Epoch `json:"toEpoch,omitempty"`
 }
 
+func (r *CfxEpochRange) UnmarshalJSON(data []byte) error {
+	type plain CfxEpochRange
+	var decoded plain
+
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid epoch range")
+	}
+
+	if err := validateJSONObjectFields(data, nil, []string{"fromEpoch", "toEpoch"}); err != nil {
+		return err
+	}
+
+	*r = CfxEpochRange(decoded)
+	return nil
+}
+
 type CfxScanLogFilter struct {
 	EpochRange *CfxEpochRange      `json:"epochRange,omitempty"`
 	Address    *cfxaddress.Address `json:"address,omitempty"`
 	Topic0     *cfxtypes.Hash      `json:"topic0,omitempty"`
+}
+
+func (f *CfxScanLogFilter) UnmarshalJSON(data []byte) error {
+	type plain CfxScanLogFilter
+	var decoded plain
+
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid core scan filter")
+	}
+	if err := validateJSONObjectFields(data, nil, []string{"epochRange", "address", "topic0"}); err != nil {
+		return err
+	}
+	*f = CfxScanLogFilter(decoded)
+	return nil
 }
 
 // CfxScanLogRequest is the JSON-RPC request shape. EpochRange may still contain
@@ -33,11 +64,36 @@ type CfxScanLogRequest struct {
 	Reverse bool             `json:"reverse,omitempty"`
 }
 
+func (r CfxScanLogRequest) ContractAddress() (string, bool) {
+	if r.Filter.Address == nil {
+		return "", false
+	}
+	return r.Filter.Address.MustGetBase32Address(), true
+}
+
+func (r *CfxScanLogRequest) UnmarshalJSON(data []byte) error {
+	type plain CfxScanLogRequest
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid core scan request")
+	}
+	if err := validateJSONObjectFields(
+		data,
+		[]string{"filter"},
+		[]string{"filter", "limit", "cursor", "reverse"},
+	); err != nil {
+		return err
+	}
+	*r = CfxScanLogRequest(decoded)
+	return nil
+}
+
 // CfxScanLogParams is the Handler input produced by the RPC normalization
-// layer. EpochRange is numeric, frozen and capped for the entire request.
+// layer. EpochRange is numeric, frozen and validated for the entire request.
 type CfxScanLogParams struct {
 	*CfxScanLogRequest
-	EpochRange types.RangeUint64
+	EpochRange          types.RangeUint64
+	WithPivotAssumption bool
 }
 
 // `CfxPivotAssumption` identifies the canonical pivot block for an epoch.
@@ -46,6 +102,24 @@ type CfxPivotAssumption struct {
 	EpochNumber    hexutil.Uint64 `json:"epochNumber"`
 	PivotBlockHash cfxtypes.Hash  `json:"pivotBlockHash"`
 }
+
+func (a *CfxPivotAssumption) UnmarshalJSON(data []byte) error {
+	type plain CfxPivotAssumption
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid core pivot assumption")
+	}
+	if err := validateJSONObjectFields(
+		data,
+		[]string{"epochNumber", "pivotBlockHash"},
+		[]string{"epochNumber", "pivotBlockHash"},
+	); err != nil {
+		return err
+	}
+	*a = CfxPivotAssumption(decoded)
+	return nil
+}
+
 type CfxPivotGuard CfxPivotAssumption
 
 type CfxScanLogResult struct {
@@ -62,6 +136,98 @@ type cfxScanClient interface {
 	GetBlockSummaryByEpoch(*cfxtypes.Epoch) (*cfxtypes.BlockSummary, error)
 	GetBlockSummaryByBlockNumber(hexutil.Uint64) (*cfxtypes.BlockSummary, error)
 	GetLogs(cfxtypes.LogFilter) ([]cfxtypes.Log, error)
+}
+
+type cfxEpochNumberResolver interface {
+	GetEpochNumber(...*cfxtypes.Epoch) (*hexutil.Big, error)
+}
+
+func NormalizeCfxScanLogRequest(
+	resolver cfxEpochNumberResolver,
+	req CfxScanLogRequest,
+	withPivotAssumption bool,
+) (CfxScanLogParams, error) {
+	// Normalize log limit
+	effectiveLimit, err := normalizeScanLogsLimit(req.Limit)
+	if err != nil {
+		return CfxScanLogParams{}, errors.WithMessage(err, "failed to normalize scan log limit")
+	}
+	req.Limit = effectiveLimit
+
+	// Normalize epoch range
+	from, to := cfxtypes.EpochLatestState, cfxtypes.EpochLatestState
+	if req.Filter.EpochRange != nil {
+		if req.Filter.EpochRange.From != nil {
+			from = req.Filter.EpochRange.From
+		}
+		if req.Filter.EpochRange.To != nil {
+			to = req.Filter.EpochRange.To
+		}
+	}
+
+	resolvedTags := make(map[string]uint64)
+	resolveEpoch := func(epoch *cfxtypes.Epoch) (uint64, error) {
+		if epochNum, ok := epoch.ToInt(); ok {
+			return epochNum.Uint64(), nil
+		}
+
+		key := epoch.String()
+		if epochNum, ok := resolvedTags[key]; ok {
+			return epochNum, nil
+		}
+
+		epochNum, err := resolver.GetEpochNumber(epoch)
+		if err != nil {
+			return 0, errors.WithMessagef(err, "failed to resolve epoch tag %s", epoch)
+		}
+		if epochNum == nil {
+			return 0, errors.Errorf("failed to resolve epoch tag %s: empty epoch number", epoch)
+		}
+
+		resolved := epochNum.ToInt().Uint64()
+		resolvedTags[key] = resolved
+		return resolved, nil
+	}
+
+	fromNumber, err := resolveEpoch(from)
+	if err != nil {
+		return CfxScanLogParams{}, err
+	}
+	toNumber, err := resolveEpoch(to)
+	if err != nil {
+		return CfxScanLogParams{}, err
+	}
+	if fromNumber > toNumber {
+		return CfxScanLogParams{}, errors.WithMessagef(
+			ErrScanLogsInvalidParams,
+			"invalid epoch range: from epoch %s exceeds to epoch %s", from, to,
+		)
+	}
+
+	// Numeric upper bounds are caller assertions rather than dynamic tags. Freeze
+	// latest_state once at the request boundary and reject a future assertion;
+	// silently truncating it would make the client mistake a short page for EOF.
+	if _, explicitUpper := to.ToInt(); explicitUpper {
+		latestState, err := resolveEpoch(cfxtypes.EpochLatestState)
+		if err != nil {
+			return CfxScanLogParams{}, err
+		}
+
+		if toNumber > latestState {
+			return CfxScanLogParams{}, errors.WithMessagef(
+				ErrScanLogsInvalidParams,
+				"explicit toEpoch %d exceeds frozen latest_state %d", toNumber, latestState,
+			)
+		}
+	}
+
+	return CfxScanLogParams{
+		CfxScanLogRequest: &req,
+		EpochRange: types.RangeUint64{
+			From: fromNumber, To: toNumber,
+		},
+		WithPivotAssumption: withPivotAssumption,
+	}, nil
 }
 
 type cfxScanGeneration struct {
@@ -205,7 +371,7 @@ func (handler *CfxLogsApiHandler) buildCfxGeneration(req CfxScanLogParams) (cfxS
 	}
 
 	// The RPC layer has already resolved tags to numeric epochs and
-	// frozen/capped the effective numeric range. The Handler only intersects that
+	// frozen and validated the effective numeric range. The Handler only intersects that
 	// range with the DB watermark.
 	if latest.Epoch >= req.EpochRange.To {
 		gen.fnEpochs = emptyScanRange
@@ -370,7 +536,7 @@ func (handler *CfxLogsApiHandler) finishCfxCandidate(
 	result := &CfxScanLogResult{Logs: logs, NextCursor: tail.clone()}
 	usage := cfxScanUsage{db: dbUsed, fn: fnUsed}
 
-	if assumption == nil {
+	if assumption == nil && (!req.WithPivotAssumption || len(logs) == 0) {
 		result.usage = usage
 		return result, nil
 	}
@@ -463,9 +629,40 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 	cfx cfxScanClient,
 	req CfxScanLogParams,
 	assumption *CfxPivotAssumption,
+) (result *CfxScanLogResult, err error) {
+	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
+		return nil, errors.WithMessage(
+			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
+		)
+	}
+	recorder := newScanLogsMetrics("cfx", req.WithPivotAssumption)
+	ctx = withScanLogsMetrics(ctx, recorder)
+	started := time.Now()
+	recorder.Percentage("direction/reverse", req.Reverse)
+	recorder.Histogram("limit", int64(req.Limit))
+	defer func() {
+		recorder.Duration("duration", started)
+		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
+		if result == nil {
+			return
+		}
+		recorder.Histogram("result", int64(len(result.Logs)))
+		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
+		recorder.Percentage("source/db", db && !fn)
+		recorder.Percentage("source/fn", fn && !db)
+		recorder.Percentage("source/mixed", db && fn)
+	}()
+	return handler.scanLogs(ctx, cfx, req, assumption)
+}
+
+func (handler *CfxLogsApiHandler) scanLogs(
+	ctx context.Context,
+	cfx cfxScanClient,
+	req CfxScanLogParams,
+	assumption *CfxPivotAssumption,
 ) (*CfxScanLogResult, error) {
-	if req.Limit == 0 || uint64(req.Limit) > store.MaxLogLimit {
-		return nil, errors.Errorf("scan limit must be in [1, %d]", store.MaxLogLimit)
+	if req.Limit == 0 || uint64(req.Limit) > maxScanLogsLimit {
+		return nil, errors.WithMessagef(ErrScanLogsInvalidParams, "scan limit must be in [1, %d]", maxScanLogsLimit)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, store.TimeoutGetLogs)
@@ -492,12 +689,15 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 				// and return directly without entering a commit fence.
 				_, retryOuter, commitErr := handler.commitCfxDBGeneration(v0, nil, err)
 				if retryOuter {
+					markScanLogsMetric(ctx, "retry/db_outer")
 					continue
 				}
 				return nil, commitErr
 			}
 			return nil, errors.WithMessage(err, "failed to build scan generation")
 		}
+		recordScanLogsHistogram(ctx, "plan/segments", int64(len(gen.plan.segments)))
+		recordScanLogsHistogram(ctx, "plan/cursor_owner", int64(gen.owner))
 
 		// Cache lifetime is exactly this outer generation. FN-only plans do not
 		// allocate one; a cache survives inner retries but never an outer restart.
@@ -514,6 +714,7 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 		if assumptionErr != nil {
 			_, retryOuter, err := handler.commitCfxDBGeneration(v0, nil, assumptionErr)
 			if retryOuter {
+				markScanLogsMetric(ctx, "retry/db_outer")
 				continue
 			}
 			return nil, err
@@ -536,6 +737,7 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 
 				result, retryOuter, err := handler.commitCfxDBGeneration(v0, result, provisionalErr)
 				if retryOuter {
+					markScanLogsMetric(ctx, "retry/db_outer")
 					continue
 				}
 				return result, err
@@ -552,6 +754,7 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 			}
 			result, retryOuter, err := handler.commitCfxDBGeneration(v0, result, provisionalErr)
 			if retryOuter {
+				markScanLogsMetric(ctx, "retry/db_outer")
 				continue
 			}
 			return result, err
@@ -569,6 +772,7 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 			ctx, cfx, req, assumption, outer,
 		)
 		if retryOuter {
+			markScanLogsMetric(ctx, "retry/db_outer")
 			continue
 		}
 		return result, err
@@ -673,6 +877,7 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 		// The before summary both identifies the FN view and bounds all cursor BN
 		// lookups that may occur while building this candidate.
 		before, err := cfx.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(h))
+		markScanLogsMetric(ctx, "core/checkpoint_before")
 		if err != nil {
 			return nil, false, errors.WithMessage(err, "failed to get pivot block summary")
 		}
@@ -683,6 +888,7 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 			// a fence, so fail this node call directly.
 			return nil, false, err
 		}
+		attempt.metrics = scanLogsMetricsFromContext(ctx)
 
 		candidate, err := handler.buildCfxInnerCandidate(ctx, cfx, req, assumption, outer, attempt)
 		if err != nil {
@@ -717,6 +923,7 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 		// Eliminating ABA requires a node-provided immutable view token or atomic
 		// range RPC; JSON-RPC batch does not provide that guarantee.
 		after, err := cfx.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(h))
+		markScanLogsMetric(ctx, "core/checkpoint_after")
 		if err != nil {
 			return nil, false, errors.WithMessagef(err, "failed to get block summary for epoch %d", h)
 		}
@@ -741,8 +948,11 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 		case canonicalRetryOuter:
 			return nil, true, nil
 		case canonicalRetryInner:
+			markScanLogsMetric(ctx, "retry/fn_inner")
 			if boundaryMismatch && checkpointStable {
+				markScanLogsMetric(ctx, "boundary/mismatch")
 				if boundaryRetries >= maxBoundaryInnerRetries {
+					markScanLogsMetric(ctx, "boundary/convergence_failure")
 					return nil, false, errors.WithMessagef(
 						ErrScanLogsConsistency, "mixed boundary mismatch after %d retry", boundaryRetries,
 					)
@@ -860,6 +1070,7 @@ type cfxFNAttemptView struct {
 	pivots          map[uint64]cfxBlockRef
 	byNumber        map[uint64]cfxBlockRef
 	byHash          map[cfxtypes.Hash]cfxBlockRef
+	metrics         scanLogsMetricsRecorder
 }
 
 func newCfxFNAttemptView(
@@ -896,6 +1107,9 @@ func (v *cfxFNAttemptView) rememberPivot(ref cfxBlockRef) {
 
 func (v *cfxFNAttemptView) pivot(epoch uint64) (cfxBlockRef, error) {
 	if ref, ok := v.pivots[epoch]; ok {
+		if v.metrics != nil {
+			v.metrics.Mark("core/pivot_cache_reuse")
+		}
 		return ref, nil
 	}
 
@@ -907,6 +1121,9 @@ func (v *cfxFNAttemptView) pivot(epoch uint64) (cfxBlockRef, error) {
 	}
 
 	summary, err := v.client.GetBlockSummaryByEpoch(cfxtypes.NewEpochNumberUint64(epoch))
+	if v.metrics != nil {
+		v.metrics.Mark("core/pivot_rpc")
+	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(
 			err, "failed to get pivot summary for epoch %d", epoch,
@@ -945,6 +1162,9 @@ func (v *cfxFNAttemptView) block(number uint64) (cfxBlockRef, error) {
 	}
 
 	summary, err := v.client.GetBlockSummaryByBlockNumber(hexutil.Uint64(number))
+	if v.metrics != nil {
+		v.metrics.Mark("core/cursor_summary")
+	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(
 			err, "failed to get block summary for block %d", number,
@@ -974,6 +1194,9 @@ func (v *cfxFNAttemptView) blockByHash(hash cfxtypes.Hash) (cfxBlockRef, error) 
 	}
 
 	summary, err := v.client.GetBlockSummaryByHash(hash)
+	if v.metrics != nil {
+		v.metrics.Mark("core/tail_position_rpc")
+	}
 	if err != nil {
 		return cfxBlockRef{}, errors.WithMessagef(
 			err, "failed to get block summary for hash %s", hash,

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"time"
 
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
@@ -16,10 +17,36 @@ type EthBlockRange struct {
 	To   *web3types.BlockNumber `json:"toBlock,omitempty"`
 }
 
+func (r *EthBlockRange) UnmarshalJSON(data []byte) error {
+	type plain EthBlockRange
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid eSpace block range")
+	}
+	if err := validateJSONObjectFields(data, nil, []string{"fromBlock", "toBlock"}); err != nil {
+		return err
+	}
+	*r = EthBlockRange(decoded)
+	return nil
+}
+
 type EthScanLogFilter struct {
 	BlockRange *EthBlockRange  `json:"blockRange,omitempty"`
 	Address    *common.Address `json:"address,omitempty"`
 	Topic0     *common.Hash    `json:"topic0,omitempty"`
+}
+
+func (f *EthScanLogFilter) UnmarshalJSON(data []byte) error {
+	type plain EthScanLogFilter
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid eSpace scan filter")
+	}
+	if err := validateJSONObjectFields(data, nil, []string{"blockRange", "address", "topic0"}); err != nil {
+		return err
+	}
+	*f = EthScanLogFilter(decoded)
+	return nil
 }
 
 type EthScanLogRequest struct {
@@ -29,9 +56,34 @@ type EthScanLogRequest struct {
 	Reverse bool             `json:"reverse,omitempty"`
 }
 
+func (r EthScanLogRequest) ContractAddress() (string, bool) {
+	if r.Filter.Address == nil {
+		return "", false
+	}
+	return r.Filter.Address.String(), true
+}
+
+func (r *EthScanLogRequest) UnmarshalJSON(data []byte) error {
+	type plain EthScanLogRequest
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid eSpace scan request")
+	}
+	if err := validateJSONObjectFields(
+		data,
+		[]string{"filter"},
+		[]string{"filter", "limit", "cursor", "reverse"},
+	); err != nil {
+		return err
+	}
+	*r = EthScanLogRequest(decoded)
+	return nil
+}
+
 type EthScanLogParams struct {
 	*EthScanLogRequest
-	BlockRange types.RangeUint64
+	BlockRange          types.RangeUint64
+	WithPivotAssumption bool
 }
 
 // EthPivotAssumption identifies one canonical eSpace block and doubles as the
@@ -40,6 +92,24 @@ type EthPivotAssumption struct {
 	BlockNumber hexutil.Uint64 `json:"blockNumber"`
 	BlockHash   common.Hash    `json:"blockHash"`
 }
+
+func (a *EthPivotAssumption) UnmarshalJSON(data []byte) error {
+	type plain EthPivotAssumption
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid eSpace pivot assumption")
+	}
+	if err := validateJSONObjectFields(
+		data,
+		[]string{"blockNumber", "blockHash"},
+		[]string{"blockNumber", "blockHash"},
+	); err != nil {
+		return err
+	}
+	*a = EthPivotAssumption(decoded)
+	return nil
+}
+
 type EthPivotGuard EthPivotAssumption
 
 // EthScanLogResult keeps native web3go logs. The unexported usage field tracks
@@ -56,6 +126,112 @@ type EthScanLogResult struct {
 type ethScanClient interface {
 	BlockByNumber(web3types.BlockNumber, bool) (*web3types.Block, error)
 	Logs(web3types.FilterQuery) ([]web3types.Log, error)
+}
+
+type ethBlockNumberResolver interface {
+	BlockByNumber(web3types.BlockNumber, bool) (*web3types.Block, error)
+}
+
+func NormalizeEthScanLogRequest(
+	resolver ethBlockNumberResolver,
+	hardfork web3types.BlockNumber,
+	req EthScanLogRequest,
+	withPivotAssumption bool,
+) (EthScanLogParams, error) {
+	effectiveLimit, err := normalizeScanLogsLimit(req.Limit)
+	if err != nil {
+		return EthScanLogParams{}, err
+	}
+	req.Limit = effectiveLimit
+
+	from, to := web3types.LatestBlockNumber, web3types.LatestBlockNumber
+	if req.Filter.BlockRange != nil {
+		if req.Filter.BlockRange.From != nil {
+			from = *req.Filter.BlockRange.From
+		}
+		if req.Filter.BlockRange.To != nil {
+			to = *req.Filter.BlockRange.To
+		}
+	}
+
+	resolvedTags := make(map[web3types.BlockNumber]uint64)
+	resolveBlock := func(blockNum web3types.BlockNumber) (uint64, error) {
+		if blockNum > 0 {
+			return uint64(blockNum), nil
+		}
+
+		if resolved, ok := resolvedTags[blockNum]; ok {
+			return resolved, nil
+		}
+
+		block, err := resolver.BlockByNumber(blockNum, false)
+		if err != nil {
+			return 0, errors.WithMessagef(err, "failed to resolve block by tag %s", blockNum)
+		}
+		if block == nil || block.Number == nil {
+			return 0, errors.WithMessagef(
+				ErrScanLogsInvalidParams,
+				"unavailable block by tag %s", blockNum,
+			)
+		}
+		resolved := block.Number.Uint64()
+		resolvedTags[blockNum] = resolved
+		return resolved, nil
+	}
+
+	fromNumber, err := resolveBlock(from)
+	if err != nil {
+		return EthScanLogParams{}, err
+	}
+	toNumber, err := resolveBlock(to)
+	if err != nil {
+		return EthScanLogParams{}, err
+	}
+	if fromNumber > toNumber {
+		return EthScanLogParams{}, errors.WithMessagef(
+			ErrScanLogsInvalidParams,
+			"invalid block range: from block %s exceeds to block %s", from, to,
+		)
+	}
+
+	// A numeric upper bound is explicit caller input. Compare it with one frozen
+	// latest head and fail instead of truncating the requested range.
+	if to >= 0 {
+		latest, err := resolveBlock(web3types.LatestBlockNumber)
+		if err != nil {
+			return EthScanLogParams{}, err
+		}
+		if toNumber > latest {
+			return EthScanLogParams{}, errors.WithMessagef(
+				ErrScanLogsInvalidParams,
+				"explicit toBlock %d exceeds frozen latest %d", toNumber, latest,
+			)
+		}
+	}
+
+	// eSpace has no logs before the transition height. Preserve a wholly
+	// pre-transition request as empty instead of moving it onto the hardfork block.
+	var effectiveBlockRange scanRange
+	if hardforkNumber := uint64(hardfork); toNumber <= hardforkNumber {
+		effectiveBlockRange = emptyScanRange
+	} else {
+		effectiveBlockRange = scanRange{
+			From: max(fromNumber, hardforkNumber),
+			To:   toNumber,
+		}
+	}
+
+	if req.Cursor != nil && !effectiveBlockRange.contains(uint64(req.Cursor.BlockNumber)) {
+		return EthScanLogParams{}, errors.WithMessage(
+			ErrScanLogsInvalidCursor, "cursor is outside the normalized block range",
+		)
+	}
+
+	return EthScanLogParams{
+		EthScanLogRequest:   &req,
+		BlockRange:          types.RangeUint64(effectiveBlockRange),
+		WithPivotAssumption: withPivotAssumption,
+	}, nil
 }
 
 type ethScanGeneration struct {
@@ -95,11 +271,19 @@ func ethFNFilter(scanFilter EthScanLogFilter) web3types.FilterQuery {
 }
 
 // buildEthGeneration captures one DB-version-specific block split. The RPC
-// adapter has already resolved tags and capped a future numeric upper bound;
+// adapter has already resolved tags and rejected a future numeric upper bound;
 // this layer must not resolve latest again because doing so would change the
 // meaning of a normalized safe/finalized request.
 func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethScanGeneration, error) {
 	cursor := req.Cursor.toStoreCursor()
+	if scanRange(req.BlockRange).empty() {
+		if cursor != nil {
+			return ethScanGeneration{}, errors.WithMessage(
+				ErrScanLogsInvalidCursor, "cursor is outside of the empty request range",
+			)
+		}
+		return newEthFullnodeGeneration(emptyScanRange, nil, req.Reverse), nil
+	}
 
 	earliest, ok, err := handler.es.EarliestBlockMapping()
 	if err != nil {
@@ -149,7 +333,7 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 		dbPivot:       common.HexToHash(latest.PivotHash),
 	}
 
-	// Block tags and future numeric bounds are normalized/capped by RPC before
+	// Block tags and future numeric bounds are normalized/validated by RPC before
 	// this call. Handler planning only splits the frozen effective range at the
 	// DB watermark and must not read a newer latest head of its own.
 	if latest.BnMax >= req.BlockRange.To {
@@ -289,7 +473,7 @@ func finishEthCandidate(
 	tail *ScanLogCursor, usage ethScanUsage,
 ) *EthScanLogResult {
 	result := &EthScanLogResult{Logs: logs, NextCursor: tail.clone(), usage: usage}
-	if assumption == nil {
+	if assumption == nil && (!req.WithPivotAssumption || len(logs) == 0) {
 		return result
 	}
 
@@ -309,8 +493,6 @@ func finishEthCandidate(
 }
 
 // ScanLogs executes an eSpace scan over an already frozen numeric request.
-// Public RPC parsing, ACL and error-code mapping are added by task #4.
-//
 // It uses the same two-level protocol as Core:
 //
 //	outer: v0 -> DB coverage/assumption/cache -> v1
@@ -324,9 +506,40 @@ func (handler *EthLogsApiHandler) ScanLogs(
 	eth ethScanClient,
 	req EthScanLogParams,
 	assumption *EthPivotAssumption,
+) (result *EthScanLogResult, err error) {
+	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
+		return nil, errors.WithMessage(
+			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
+		)
+	}
+	recorder := newScanLogsMetrics("eth", req.WithPivotAssumption)
+	ctx = withScanLogsMetrics(ctx, recorder)
+	started := time.Now()
+	recorder.Percentage("direction/reverse", req.Reverse)
+	recorder.Histogram("limit", int64(req.Limit))
+	defer func() {
+		recorder.Duration("duration", started)
+		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
+		if result == nil {
+			return
+		}
+		recorder.Histogram("result", int64(len(result.Logs)))
+		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
+		recorder.Percentage("source/db", db && !fn)
+		recorder.Percentage("source/fn", fn && !db)
+		recorder.Percentage("source/mixed", db && fn)
+	}()
+	return handler.scanLogs(ctx, eth, req, assumption)
+}
+
+func (handler *EthLogsApiHandler) scanLogs(
+	ctx context.Context,
+	eth ethScanClient,
+	req EthScanLogParams,
+	assumption *EthPivotAssumption,
 ) (*EthScanLogResult, error) {
-	if req.Limit == 0 || uint64(req.Limit) > store.MaxLogLimit {
-		return nil, errors.Errorf("scan limit must be in [1, %d]", store.MaxLogLimit)
+	if req.Limit == 0 || uint64(req.Limit) > maxScanLogsLimit {
+		return nil, errors.WithMessagef(ErrScanLogsInvalidParams, "scan limit must be in [1, %d]", maxScanLogsLimit)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, store.TimeoutGetLogs)
@@ -349,12 +562,15 @@ func (handler *EthLogsApiHandler) ScanLogs(
 			if errors.Is(err, ErrScanLogsConsistency) {
 				_, retryOuter, commitErr := handler.commitEthDBGeneration(v0, nil, err)
 				if retryOuter {
+					markScanLogsMetric(ctx, "retry/db_outer")
 					continue
 				}
 				return nil, commitErr
 			}
 			return nil, err
 		}
+		recordScanLogsHistogram(ctx, "plan/segments", int64(len(gen.plan.segments)))
+		recordScanLogsHistogram(ctx, "plan/cursor_owner", int64(gen.owner))
 
 		// Cache lifetime is exactly one outer generation. It can survive FN-only
 		// retries, but a plan without a DB segment does not allocate one.
@@ -370,6 +586,7 @@ func (handler *EthLogsApiHandler) ScanLogs(
 		if assumptionErr != nil {
 			_, retryOuter, commitErr := handler.commitEthDBGeneration(v0, nil, assumptionErr)
 			if retryOuter {
+				markScanLogsMetric(ctx, "retry/db_outer")
 				continue
 			}
 			return nil, commitErr
@@ -394,6 +611,7 @@ func (handler *EthLogsApiHandler) ScanLogs(
 				)
 				result, retryOuter, commitErr := handler.commitEthDBGeneration(v0, result, nil)
 				if retryOuter {
+					markScanLogsMetric(ctx, "retry/db_outer")
 					continue
 				}
 				return result, commitErr
@@ -411,6 +629,7 @@ func (handler *EthLogsApiHandler) ScanLogs(
 
 			result, retryOuter, commitErr := handler.commitEthDBGeneration(v0, result, provisionalErr)
 			if retryOuter {
+				markScanLogsMetric(ctx, "retry/db_outer")
 				continue
 			}
 			return result, commitErr
@@ -427,6 +646,7 @@ func (handler *EthLogsApiHandler) ScanLogs(
 			ctx, eth, req, assumption, outer,
 		)
 		if retryOuter {
+			markScanLogsMetric(ctx, "retry/db_outer")
 			continue
 		}
 		return result, err
@@ -599,8 +819,11 @@ func (handler *EthLogsApiHandler) scanEthFullnodeGeneration(
 		case canonicalRetryOuter:
 			return nil, true, nil
 		case canonicalRetryInner:
+			markScanLogsMetric(ctx, "retry/fn_inner")
 			if boundaryMismatch && checkpointStable {
+				markScanLogsMetric(ctx, "boundary/mismatch")
 				if boundaryRetries >= maxBoundaryInnerRetries {
+					markScanLogsMetric(ctx, "boundary/convergence_failure")
 					return nil, false, errors.WithMessagef(
 						ErrScanLogsConsistency, "mixed boundary mismatch after %d retry", boundaryRetries,
 					)

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -525,16 +525,13 @@ func (handler *EthLogsApiHandler) ScanLogs(
 
 	defer func() {
 		recorder.Duration("duration", started)
-		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
-		if result == nil {
-			return
+		if result != nil {
+			recorder.Histogram("result", int64(len(result.Logs)))
+			db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
+			recorder.Percentage("source/db", db && !fn)
+			recorder.Percentage("source/fn", fn && !db)
+			recorder.Percentage("source/mixed", db && fn)
 		}
-
-		recorder.Histogram("result", int64(len(result.Logs)))
-		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
-		recorder.Percentage("source/db", db && !fn)
-		recorder.Percentage("source/fn", fn && !db)
-		recorder.Percentage("source/mixed", db && fn)
 	}()
 
 	return handler.scanLogs(ctx, eth, req, assumption)
@@ -709,7 +706,7 @@ func (handler *EthLogsApiHandler) checkEthDBAssumption(
 
 	if common.HexToHash(pivot) != assumption.BlockHash {
 		return true, errors.WithMessagef(
-			ErrScanLogsAssumptionNotMet,
+			ErrScanLogsAssumptionFailure,
 			"expected pivot %s got %s for block %d",
 			assumption.BlockHash, pivot, assumption.BlockNumber,
 		), nil
@@ -771,7 +768,7 @@ func (handler *EthLogsApiHandler) scanEthFullnodeGeneration(
 		if before == nil {
 			if outer.fnAssumption && uint64(assumption.BlockNumber) == checkpoint {
 				return nil, false, errors.WithMessagef(
-					ErrScanLogsAssumptionNotMet,
+					ErrScanLogsAssumptionFailure,
 					"assumption block %d is unavailable", assumption.BlockNumber,
 				)
 			}
@@ -900,13 +897,13 @@ func (handler *EthLogsApiHandler) buildEthInnerCandidate(
 		}
 		if candidate.err == nil && block == nil {
 			candidate.err = newCanonicalDependentError(
-				ErrScanLogsAssumptionNotMet,
+				ErrScanLogsAssumptionFailure,
 				"pivot assumption block %d is unavailable",
 				uint64(assumption.BlockNumber),
 			)
 		} else if candidate.err == nil && block.Hash != assumption.BlockHash {
 			candidate.err = newCanonicalDependentError(
-				ErrScanLogsAssumptionNotMet, "pivot assumption does not match",
+				ErrScanLogsAssumptionFailure, "pivot assumption does not match",
 			)
 		}
 	}

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -279,7 +279,7 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 	if scanRange(req.BlockRange).empty() {
 		if cursor != nil {
 			return ethScanGeneration{}, errors.WithMessage(
-				ErrScanLogsInvalidCursor, "cursor is outside of the empty request range",
+				ErrScanLogsInvalidCursor, "cursor is outside of the request range",
 			)
 		}
 		return newEthFullnodeGeneration(emptyScanRange, nil, req.Reverse), nil
@@ -488,7 +488,10 @@ func finishEthCandidate(
 		log = logs[0]
 	}
 
-	result.PivotGuard = &EthPivotGuard{BlockNumber: hexutil.Uint64(log.BlockNumber), BlockHash: log.BlockHash}
+	result.PivotGuard = &EthPivotGuard{
+		BlockNumber: hexutil.Uint64(log.BlockNumber),
+		BlockHash:   log.BlockHash,
+	}
 	return result
 }
 
@@ -512,23 +515,28 @@ func (handler *EthLogsApiHandler) ScanLogs(
 			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
 		)
 	}
+
 	recorder := newScanLogsMetrics("eth", req.WithPivotAssumption)
 	ctx = withScanLogsMetrics(ctx, recorder)
 	started := time.Now()
+
 	recorder.Percentage("direction/reverse", req.Reverse)
 	recorder.Histogram("limit", int64(req.Limit))
+
 	defer func() {
 		recorder.Duration("duration", started)
 		recorder.Percentage("stale", errors.Is(err, ErrScanLogsStaleCursor))
 		if result == nil {
 			return
 		}
+
 		recorder.Histogram("result", int64(len(result.Logs)))
 		db, fn := result.canonicalUsageDB(), result.canonicalUsageFN()
 		recorder.Percentage("source/db", db && !fn)
 		recorder.Percentage("source/fn", fn && !db)
 		recorder.Percentage("source/mixed", db && fn)
 	}()
+
 	return handler.scanLogs(ctx, eth, req, assumption)
 }
 
@@ -570,7 +578,7 @@ func (handler *EthLogsApiHandler) scanLogs(
 			return nil, err
 		}
 		recordScanLogsHistogram(ctx, "plan/segments", int64(len(gen.plan.segments)))
-		recordScanLogsHistogram(ctx, "plan/cursor_owner", int64(gen.owner))
+		recordScanLogsCursorOwner(ctx, gen.owner)
 
 		// Cache lifetime is exactly one outer generation. It can survive FN-only
 		// retries, but a plan without a DB segment does not allocate one.

--- a/rpc/handler/scan_logs.go
+++ b/rpc/handler/scan_logs.go
@@ -1,22 +1,90 @@
 package handler
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"slices"
 	"strings"
 	"time"
 
+	cacheTypes "github.com/Conflux-Chain/confura-data-cache/types"
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
+	confurametrics "github.com/Conflux-Chain/confura/util/metrics"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
 
+type scanLogsMetricsRecorder interface {
+	Histogram(name string, value int64)
+	Mark(name string)
+	Percentage(name string, marked bool)
+	Duration(name string, started time.Time)
+}
+
+type registryScanLogsMetrics struct{ method string }
+
+func (m registryScanLogsMetrics) Histogram(name string, value int64) {
+	confurametrics.Registry.RPC.ScanLogsHistogram(m.method, name).Update(value)
+}
+
+func (m registryScanLogsMetrics) Mark(name string) {
+	confurametrics.Registry.RPC.ScanLogsMeter(m.method, name).Mark(1)
+}
+
+func (m registryScanLogsMetrics) Percentage(name string, marked bool) {
+	confurametrics.Registry.RPC.Percentage(m.method, "scanlogs/"+name).Mark(marked)
+}
+
+func (m registryScanLogsMetrics) Duration(name string, started time.Time) {
+	confurametrics.Registry.RPC.ScanLogsTimer(m.method, name).UpdateSince(started)
+}
+
+type scanLogsMetricsContextKey struct{}
+
+func withScanLogsMetrics(ctx context.Context, recorder scanLogsMetricsRecorder) context.Context {
+	return context.WithValue(ctx, scanLogsMetricsContextKey{}, recorder)
+}
+
+func scanLogsMetricsFromContext(ctx context.Context) scanLogsMetricsRecorder {
+	recorder, _ := ctx.Value(scanLogsMetricsContextKey{}).(scanLogsMetricsRecorder)
+	return recorder
+}
+
+func markScanLogsMetric(ctx context.Context, name string) {
+	if recorder := scanLogsMetricsFromContext(ctx); recorder != nil {
+		recorder.Mark(name)
+	}
+}
+
+func recordScanLogsHistogram(ctx context.Context, name string, value int64) {
+	if recorder := scanLogsMetricsFromContext(ctx); recorder != nil {
+		recorder.Histogram(name, value)
+	}
+}
+
+func newScanLogsMetrics(space string, withPivotAssumption bool) scanLogsMetricsRecorder {
+	method := space + "_scanLogs"
+	if withPivotAssumption {
+		method += "WithPivotAssumption"
+	}
+	return registryScanLogsMetrics{method: method}
+}
+
 var (
-	ErrScanLogsInvalidCursor    = errors.New("invalid scan cursor")
-	ErrScanLogsInvalidFilter    = errors.New("invalid scan filter")
-	ErrScanLogsAssumptionNotMet = errors.New("pivot assumption violated")
-	ErrScanLogsConsistency      = errors.New("inconsistent canonical views")
+	ErrScanLogsInvalidParams = errors.New("invalid scan logs params")
+	ErrScanLogsInvalidCursor = errors.New("invalid scan logs cursor")
+	ErrScanLogsStaleCursor   = errors.New("stale scan logs cursor")
+	ErrScanLogsConsistency   = errors.New("inconsistent canonical views")
+	ErrScanLogsUnavailable   = errors.New("scan logs rpc unavailable")
+
+	// Compatibility aliases keep the task #3 handler tests and any in-repository
+	// callers source-compatible while the externally visible categories use the
+	// protocol names above.
+	ErrScanLogsInvalidFilter    = ErrScanLogsInvalidParams
+	ErrScanLogsAssumptionNotMet = ErrScanLogsStaleCursor
 )
 
 // canonicalDependentError marks an error observed from the current canonical
@@ -28,7 +96,7 @@ type canonicalDependentError struct{ err error }
 func (e *canonicalDependentError) Error() string { return e.err.Error() }
 func (e *canonicalDependentError) Unwrap() error { return e.err }
 
-func newCanonicalDependentError(err error, format string, args ...interface{}) error {
+func newCanonicalDependentError(err error, format string, args ...any) error {
 	return &canonicalDependentError{err: errors.Wrapf(err, format, args...)}
 }
 
@@ -51,6 +119,95 @@ const (
 type ScanLogCursor struct {
 	BlockNumber hexutil.Uint64 `json:"blockNumber"`
 	LogIndex    hexutil.Uint64 `json:"logIndex"`
+}
+
+func (cursor *ScanLogCursor) UnmarshalJSON(data []byte) error {
+	type plain ScanLogCursor
+	var decoded plain
+	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
+		return errors.WithMessage(err, "invalid scan cursor")
+	}
+	if err := validateJSONObjectFields(
+		data,
+		[]string{"blockNumber", "logIndex"},
+		[]string{"blockNumber", "logIndex"},
+	); err != nil {
+		return err
+	}
+	*cursor = ScanLogCursor(decoded)
+	return nil
+}
+
+// unmarshalStrictJSONObject is shared by every public scanLogs request object.
+// json.Decoder's DisallowUnknownFields only applies to the object currently
+// being decoded; nested scanLogs types implement UnmarshalJSON themselves so
+// strictness is recursive rather than only protecting the top-level request.
+func unmarshalStrictJSONObject(data []byte, dst any) error {
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		return errors.New("object must not be null")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func normalizeScanLogsLimit(limit hexutil.Uint64) (hexutil.Uint64, error) {
+	if limit == 0 {
+		return hexutil.Uint64(defaultScanLogsLimit), nil
+	}
+	if uint64(limit) > maxScanLogsLimit {
+		return 0, errors.WithMessagef(
+			ErrScanLogsInvalidParams,
+			"scan limit %d exceeds configured maximum %d", limit, maxScanLogsLimit,
+		)
+	}
+	return limit, nil
+}
+
+// EncodeScanLogsResult serializes a result once, enforces the response-size
+// limit on those exact bytes, and returns a Lazy value that reuses the payload.
+func EncodeScanLogsResult[T any](result T) (cacheTypes.Lazy[T], error) {
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return cacheTypes.Lazy[T]{}, errors.WithMessage(err, "failed to encode scan logs result")
+	}
+	if uint64(len(payload)) > maxGetLogsResponseBytes {
+		return cacheTypes.Lazy[T]{}, errors.Errorf(
+			"result body size is too large with more than %d bytes, please reduce scan limit",
+			maxGetLogsResponseBytes,
+		)
+	}
+	return cacheTypes.NewLazyWithJson[T](payload), nil
+}
+
+func validateJSONObjectFields(data []byte, required []string, nonNull []string) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	for _, name := range required {
+		if _, ok := fields[name]; !ok {
+			return errors.Errorf("missing required field %q", name)
+		}
+	}
+	for _, name := range nonNull {
+		if raw, ok := fields[name]; ok && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return errors.Errorf("field %q must not be null", name)
+		}
+	}
+	return nil
 }
 
 func (cursor *ScanLogCursor) toStoreCursor() *store.ScanCursor {
@@ -279,9 +436,14 @@ func clipBlockRangeAtCursor(blocks scanRange, cursor *store.ScanCursor, reverse 
 	return blocks, nil
 }
 
-const (
+var (
+	defaultScanLogsLimit    = uint64(100)
+	maxScanLogsLimit        = uint64(1_000)
 	defaultScanLogsFNWindow = uint64(1_000)
-	boundaryRetryBackoff    = 10 * time.Millisecond
+)
+
+const (
+	boundaryRetryBackoff = 10 * time.Millisecond
 
 	// A boundary mismatch can be a transient FN reorg, so one fresh FN view is
 	// useful. Repeating forever is unsafe operationally: the DB may still contain
@@ -376,8 +538,10 @@ func scanFNBlockWindows[L any](
 			}
 
 			windowLogs, err := readWindow(ctx, low, high)
+			markScanLogsMetric(ctx, "fn/window")
 			if err != nil {
 				if isWhitelistedFNOversizedError(err) && low < high {
+					markScanLogsMetric(ctx, "fn/shrink")
 					windowSize = max(uint64(1), (high-low+1)/2)
 					continue
 				}
@@ -399,8 +563,10 @@ func scanFNBlockWindows[L any](
 		}
 
 		windowLogs, err := readWindow(ctx, low, high)
+		markScanLogsMetric(ctx, "fn/window")
 		if err != nil {
 			if isWhitelistedFNOversizedError(err) && low < high {
+				markScanLogsMetric(ctx, "fn/shrink")
 				windowSize = max(uint64(1), (high-low+1)/2)
 				continue
 			}
@@ -444,6 +610,7 @@ func (c *dbScanCache[L]) Ensure(ctx context.Context, n int) error {
 	// for reverse FN->DB: after an FN retry, remaining may grow from 20 to 40 and
 	// only the additional 20 DB rows should be queried.
 	if n <= len(c.logs) || c.exhausted {
+		markScanLogsMetric(ctx, "db/cache_reuse")
 		return nil
 	}
 
@@ -455,6 +622,11 @@ func (c *dbScanCache[L]) Ensure(ctx context.Context, n int) error {
 	}
 
 	want := n - len(c.logs)
+	if len(c.logs) == 0 {
+		markScanLogsMetric(ctx, "db/query")
+	} else {
+		markScanLogsMetric(ctx, "db/cache_extend")
+	}
 	logs, keys, err := c.scan(ctx, cursor, want)
 	if err != nil {
 		return err

--- a/rpc/handler/scan_logs.go
+++ b/rpc/handler/scan_logs.go
@@ -65,6 +65,12 @@ func recordScanLogsHistogram(ctx context.Context, name string, value int64) {
 	}
 }
 
+func recordScanLogsPercentage(ctx context.Context, name string, marked bool) {
+	if recorder := scanLogsMetricsFromContext(ctx); recorder != nil {
+		recorder.Percentage(name, marked)
+	}
+}
+
 func newScanLogsMetrics(space string, withPivotAssumption bool) scanLogsMetricsRecorder {
 	method := space + "_scanLogs"
 	if withPivotAssumption {
@@ -289,6 +295,12 @@ const (
 	cursorOwnerDB
 	cursorOwnerFN
 )
+
+func recordScanLogsCursorOwner(ctx context.Context, owner cursorOwner) {
+	recordScanLogsPercentage(ctx, "plan/cursor_owner/none", owner == cursorOwnerNone)
+	recordScanLogsPercentage(ctx, "plan/cursor_owner/db", owner == cursorOwnerDB)
+	recordScanLogsPercentage(ctx, "plan/cursor_owner/fn", owner == cursorOwnerFN)
+}
 
 type canonicalCommitDecision uint8
 

--- a/rpc/handler/scan_logs.go
+++ b/rpc/handler/scan_logs.go
@@ -12,7 +12,7 @@ import (
 	cacheTypes "github.com/Conflux-Chain/confura-data-cache/types"
 	"github.com/Conflux-Chain/confura/store"
 	"github.com/Conflux-Chain/confura/types"
-	confurametrics "github.com/Conflux-Chain/confura/util/metrics"
+	metricUtil "github.com/Conflux-Chain/go-conflux-util/metrics"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
@@ -27,19 +27,19 @@ type scanLogsMetricsRecorder interface {
 type registryScanLogsMetrics struct{ method string }
 
 func (m registryScanLogsMetrics) Histogram(name string, value int64) {
-	confurametrics.Registry.RPC.ScanLogsHistogram(m.method, name).Update(value)
+	metricUtil.GetOrRegisterHistogram("infura/rpc/%v/%v", m.method, name).Update(value)
 }
 
 func (m registryScanLogsMetrics) Mark(name string) {
-	confurametrics.Registry.RPC.ScanLogsMeter(m.method, name).Mark(1)
+	metricUtil.GetOrRegisterMeter("infura/rpc/%v/%v", m.method, name).Mark(1)
 }
 
 func (m registryScanLogsMetrics) Percentage(name string, marked bool) {
-	confurametrics.Registry.RPC.Percentage(m.method, "scanlogs/"+name).Mark(marked)
+	metricUtil.GetOrRegisterTimeWindowPercentageDefault("infura/rpc/%v/%v", m.method, name).Mark(marked)
 }
 
 func (m registryScanLogsMetrics) Duration(name string, started time.Time) {
-	confurametrics.Registry.RPC.ScanLogsTimer(m.method, name).UpdateSince(started)
+	metricUtil.GetOrRegisterTimer("infura/rpc/%v/%v", m.method, name).UpdateSince(started)
 }
 
 type scanLogsMetricsContextKey struct{}
@@ -80,17 +80,14 @@ func newScanLogsMetrics(space string, withPivotAssumption bool) scanLogsMetricsR
 }
 
 var (
+	ErrScanLogsUnavailable = errors.New("scan logs rpc unavailable")
+
 	ErrScanLogsInvalidParams = errors.New("invalid scan logs params")
 	ErrScanLogsInvalidCursor = errors.New("invalid scan logs cursor")
-	ErrScanLogsStaleCursor   = errors.New("stale scan logs cursor")
-	ErrScanLogsConsistency   = errors.New("inconsistent canonical views")
-	ErrScanLogsUnavailable   = errors.New("scan logs rpc unavailable")
+	ErrScanLogsInvalidFilter = errors.New("invalid scan log filter")
 
-	// Compatibility aliases keep the task #3 handler tests and any in-repository
-	// callers source-compatible while the externally visible categories use the
-	// protocol names above.
-	ErrScanLogsInvalidFilter    = ErrScanLogsInvalidParams
-	ErrScanLogsAssumptionNotMet = ErrScanLogsStaleCursor
+	ErrScanLogsConsistency       = errors.New("inconsistent canonical views")
+	ErrScanLogsAssumptionFailure = errors.New("pivot assumption failed")
 )
 
 // canonicalDependentError marks an error observed from the current canonical

--- a/rpc/handler/scan_logs_rpc_test.go
+++ b/rpc/handler/scan_logs_rpc_test.go
@@ -1,0 +1,420 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/Conflux-Chain/confura/store"
+	citypes "github.com/Conflux-Chain/confura/types"
+	cfxtypes "github.com/Conflux-Chain/go-conflux-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	web3types "github.com/openweb3/web3go/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCfxEpochNumberResolver struct {
+	values map[string]uint64
+	calls  []string
+}
+
+func (r *fakeCfxEpochNumberResolver) GetEpochNumber(epochs ...*cfxtypes.Epoch) (*hexutil.Big, error) {
+	if len(epochs) != 1 || epochs[0] == nil {
+		return nil, errors.New("expected exactly one epoch tag")
+	}
+
+	key := epochs[0].String()
+	r.calls = append(r.calls, key)
+	value, ok := r.values[key]
+	if !ok {
+		return nil, errors.Errorf("unexpected epoch tag %s", key)
+	}
+	return (*hexutil.Big)(new(big.Int).SetUint64(value)), nil
+}
+
+type fakeEthBlockNumberResolver struct {
+	values map[web3types.BlockNumber]uint64
+	calls  []web3types.BlockNumber
+}
+
+func (r *fakeEthBlockNumberResolver) BlockByNumber(
+	blockNumber web3types.BlockNumber, _ bool,
+) (*web3types.Block, error) {
+	r.calls = append(r.calls, blockNumber)
+	value, ok := r.values[blockNumber]
+	if !ok {
+		return nil, errors.Errorf("unexpected block tag %s", blockNumber)
+	}
+	return &web3types.Block{Number: new(big.Int).SetUint64(value)}, nil
+}
+
+func epochNumber(value uint64) *cfxtypes.Epoch {
+	return cfxtypes.NewEpochNumberUint64(value)
+}
+
+func blockNumber(value web3types.BlockNumber) *web3types.BlockNumber {
+	return &value
+}
+
+func TestNormalizeCfxScanLogRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		from      *cfxtypes.Epoch
+		to        *cfxtypes.Epoch
+		values    map[string]uint64
+		wantRange citypes.RangeUint64
+		wantErr   error
+		wantCalls map[string]int
+	}{
+		{
+			name: "numeric range freezes latest for validation",
+			from: epochNumber(10), to: epochNumber(100),
+			values:    map[string]uint64{cfxtypes.EpochLatestState.String(): 100},
+			wantRange: citypes.RangeUint64{From: 10, To: 100},
+			wantCalls: map[string]int{cfxtypes.EpochLatestState.String(): 1},
+		},
+		{
+			name: "numeric future upper bound",
+			from: epochNumber(10), to: epochNumber(101),
+			values:    map[string]uint64{cfxtypes.EpochLatestState.String(): 100},
+			wantErr:   ErrScanLogsInvalidParams,
+			wantCalls: map[string]int{cfxtypes.EpochLatestState.String(): 1},
+		},
+		{
+			name: "repeated latest tag is resolved once",
+			from: cfxtypes.EpochLatestState, to: cfxtypes.EpochLatestState,
+			values:    map[string]uint64{cfxtypes.EpochLatestState.String(): 100},
+			wantRange: citypes.RangeUint64{From: 100, To: 100},
+			wantCalls: map[string]int{cfxtypes.EpochLatestState.String(): 1},
+		},
+		{
+			name: "distinct dynamic tags are each frozen once",
+			from: cfxtypes.EpochLatestConfirmed, to: cfxtypes.EpochLatestState,
+			values: map[string]uint64{
+				cfxtypes.EpochLatestConfirmed.String(): 90,
+				cfxtypes.EpochLatestState.String():     100,
+			},
+			wantRange: citypes.RangeUint64{From: 90, To: 100},
+			wantCalls: map[string]int{
+				cfxtypes.EpochLatestConfirmed.String(): 1,
+				cfxtypes.EpochLatestState.String():     1,
+			},
+		},
+		{
+			name: "reversed numeric range",
+			from: epochNumber(20), to: epochNumber(10),
+			wantErr: ErrScanLogsInvalidParams,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &fakeCfxEpochNumberResolver{values: test.values}
+			params, err := NormalizeCfxScanLogRequest(
+				resolver,
+				CfxScanLogRequest{
+					Filter: CfxScanLogFilter{EpochRange: &CfxEpochRange{From: test.from, To: test.to}},
+					Limit:  1,
+				},
+				false,
+			)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantRange, params.EpochRange)
+			}
+
+			actualCalls := make(map[string]int)
+			for _, call := range resolver.calls {
+				actualCalls[call]++
+			}
+			if test.wantCalls == nil {
+				require.Empty(t, actualCalls)
+			} else {
+				require.Equal(t, test.wantCalls, actualCalls)
+			}
+		})
+	}
+}
+
+func TestNormalizeEthScanLogRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		from      *web3types.BlockNumber
+		to        *web3types.BlockNumber
+		cursor    *ScanLogCursor
+		hardfork  web3types.BlockNumber
+		values    map[web3types.BlockNumber]uint64
+		wantRange citypes.RangeUint64
+		wantErr   error
+		wantCalls map[web3types.BlockNumber]int
+	}{
+		{
+			name: "numeric range freezes latest for validation",
+			from: blockNumber(10), to: blockNumber(100), hardfork: 5,
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantRange: citypes.RangeUint64{From: 10, To: 100},
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name: "numeric future upper bound",
+			from: blockNumber(10), to: blockNumber(101), hardfork: 5,
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantErr:   ErrScanLogsInvalidParams,
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name:      "repeated latest tag is resolved once",
+			from:      blockNumber(web3types.LatestBlockNumber),
+			to:        blockNumber(web3types.LatestBlockNumber),
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantRange: citypes.RangeUint64{From: 100, To: 100},
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name: "distinct dynamic tags are each frozen once",
+			from: blockNumber(web3types.SafeBlockNumber),
+			to:   blockNumber(web3types.LatestBlockNumber),
+			values: map[web3types.BlockNumber]uint64{
+				web3types.SafeBlockNumber:   90,
+				web3types.LatestBlockNumber: 100,
+			},
+			wantRange: citypes.RangeUint64{From: 90, To: 100},
+			wantCalls: map[web3types.BlockNumber]int{
+				web3types.SafeBlockNumber:   1,
+				web3types.LatestBlockNumber: 1,
+			},
+		},
+		{
+			name: "reversed numeric range is rejected before hardfork clipping",
+			from: blockNumber(9), to: blockNumber(8), hardfork: 10,
+			wantErr: ErrScanLogsInvalidParams,
+		},
+		{
+			name: "range entirely before hardfork is empty",
+			from: blockNumber(1), to: blockNumber(9), hardfork: 10,
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantRange: citypes.RangeUint64(emptyScanRange),
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name: "range crossing hardfork starts at hardfork",
+			from: blockNumber(1), to: blockNumber(11), hardfork: 10,
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantRange: citypes.RangeUint64{From: 10, To: 11},
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name: "cursor outside frozen range",
+			from: blockNumber(10), to: blockNumber(50), hardfork: 5,
+			cursor:    &ScanLogCursor{BlockNumber: 51},
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantErr:   ErrScanLogsInvalidCursor,
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+		{
+			name: "cursor inside normalized range",
+			from: blockNumber(1), to: blockNumber(20), hardfork: 10,
+			cursor:    &ScanLogCursor{BlockNumber: 15},
+			values:    map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100},
+			wantRange: citypes.RangeUint64{From: 10, To: 20},
+			wantCalls: map[web3types.BlockNumber]int{web3types.LatestBlockNumber: 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &fakeEthBlockNumberResolver{values: test.values}
+			params, err := NormalizeEthScanLogRequest(
+				resolver,
+				test.hardfork,
+				EthScanLogRequest{
+					Filter: EthScanLogFilter{BlockRange: &EthBlockRange{From: test.from, To: test.to}},
+					Limit:  1,
+					Cursor: test.cursor,
+				},
+				false,
+			)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantRange, params.BlockRange)
+			}
+
+			actualCalls := make(map[web3types.BlockNumber]int)
+			for _, call := range resolver.calls {
+				actualCalls[call]++
+			}
+			if test.wantCalls == nil {
+				require.Empty(t, actualCalls)
+			} else {
+				require.Equal(t, test.wantCalls, actualCalls)
+			}
+		})
+	}
+}
+
+func TestScanLogsStrictJSON(t *testing.T) {
+	validHash := common.HexToHash("0x1").String()
+	tests := []struct {
+		name string
+		data string
+		dst  interface{}
+	}{
+		{"missing filter", `{}`, new(CfxScanLogRequest)},
+		{"null filter", `{"filter":null}`, new(EthScanLogRequest)},
+		{"request unknown", `{"filter":{},"blockHash":"0x1"}`, new(CfxScanLogRequest)},
+		{"filter unknown", `{"filter":{"topics":[]}}`, new(EthScanLogRequest)},
+		{"range unknown", `{"filter":{"epochRange":{"from":"0x1"}}}`, new(CfxScanLogRequest)},
+		{"cursor unknown", `{"filter":{},"cursor":{"blockNumber":"0x1","logIndex":"0x0","source":"db"}}`, new(EthScanLogRequest)},
+		{"assumption missing", `{"blockNumber":"0x1"}`, new(EthPivotAssumption)},
+		{"assumption unknown", `{"blockNumber":"0x1","blockHash":"` + validHash + `","extra":true}`, new(EthPivotAssumption)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Error(t, json.Unmarshal([]byte(test.data), test.dst))
+		})
+	}
+}
+
+func TestScanLogsJSONQuantitiesAndFirstPageGuard(t *testing.T) {
+	var req EthScanLogRequest
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"filter":{"blockRange":{"fromBlock":"0x1","toBlock":"latest"}},
+		"limit":"0x64",
+		"cursor":{"blockNumber":"0xa","logIndex":"0x2"}
+	}`), &req))
+	require.Equal(t, hexutil.Uint64(100), req.Limit)
+	require.Equal(t, hexutil.Uint64(10), req.Cursor.BlockNumber)
+
+	log := web3types.Log{BlockNumber: 10, BlockHash: common.HexToHash("0x1234")}
+	result := finishEthCandidate(
+		EthScanLogParams{
+			EthScanLogRequest:   &EthScanLogRequest{Limit: 1},
+			WithPivotAssumption: true,
+		},
+		nil,
+		[]web3types.Log{log},
+		&ScanLogCursor{BlockNumber: 10},
+		ethScanUsage{fn: true},
+	)
+	require.NotNil(t, result.PivotGuard)
+	require.Equal(t, hexutil.Uint64(10), result.PivotGuard.BlockNumber)
+
+	empty := finishEthCandidate(
+		EthScanLogParams{
+			EthScanLogRequest:   &EthScanLogRequest{Limit: 1},
+			WithPivotAssumption: true,
+		},
+		nil,
+		nil,
+		nil,
+		ethScanUsage{fn: true},
+	)
+	require.Nil(t, empty.PivotGuard)
+
+	db := newScanLogsHandlerTestDB(t)
+	pivot := common.HexToHash("0x1234")
+	insertScanLogsMapping(t, db, 10, 10, 10, pivot.String())
+	cfxHandler := newTestCfxScanLogsHandler(db)
+	epochNumber := (*hexutil.Big)(new(big.Int).SetUint64(10))
+	cfxResult, err := cfxHandler.finishCfxCandidate(
+		CfxScanLogParams{
+			CfxScanLogRequest:   &CfxScanLogRequest{Limit: 1},
+			WithPivotAssumption: true,
+		},
+		nil,
+		cfxScanGeneration{dbAvailable: true, dbMaxEpoch: 10},
+		[]cfxtypes.Log{{EpochNumber: epochNumber}},
+		&ScanLogCursor{BlockNumber: 10},
+		true,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cfxResult.PivotGuard)
+	require.Equal(t, cfxtypes.Hash(pivot.String()), cfxResult.PivotGuard.PivotBlockHash)
+}
+
+func TestNormalizeScanLogsLimit(t *testing.T) {
+	oldDefault, oldMax := defaultScanLogsLimit, maxScanLogsLimit
+	t.Cleanup(func() {
+		defaultScanLogsLimit, maxScanLogsLimit = oldDefault, oldMax
+	})
+	defaultScanLogsLimit, maxScanLogsLimit = 25, 50
+
+	limit, err := normalizeScanLogsLimit(0)
+	require.NoError(t, err)
+	require.Equal(t, hexutil.Uint64(25), limit)
+	_, err = normalizeScanLogsLimit(51)
+	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
+}
+
+func TestEncodeScanLogsResult(t *testing.T) {
+	oldMaxBytes := maxGetLogsResponseBytes
+	t.Cleanup(func() { maxGetLogsResponseBytes = oldMaxBytes })
+
+	result := &EthScanLogResult{Logs: []web3types.Log{}}
+	maxGetLogsResponseBytes = 1024
+	lazy, err := EncodeScanLogsResult(result)
+	require.NoError(t, err)
+	expected, err := json.Marshal(result)
+	require.NoError(t, err)
+	actual, err := json.Marshal(lazy)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+
+	maxGetLogsResponseBytes = 2
+	_, err = EncodeScanLogsResult(result)
+	require.Error(t, err)
+}
+
+type recordingScanLogsMetrics struct {
+	marks map[string]int
+}
+
+func (m *recordingScanLogsMetrics) Histogram(string, int64)    {}
+func (m *recordingScanLogsMetrics) Percentage(string, bool)    {}
+func (m *recordingScanLogsMetrics) Duration(string, time.Time) {}
+func (m *recordingScanLogsMetrics) Mark(name string)           { m.marks[name]++ }
+
+func TestScanLogsMetricsRecorderCoversWindowsAndDBCache(t *testing.T) {
+	recorder := &recordingScanLogsMetrics{marks: make(map[string]int)}
+	ctx := withScanLogsMetrics(context.Background(), recorder)
+	reads := 0
+	_, err := scanFNBlockWindows(
+		ctx,
+		scanRange{From: 1, To: 2},
+		false,
+		2,
+		1,
+		func(context.Context, uint64, uint64) ([]int, error) {
+			reads++
+			if reads == 1 {
+				return nil, errors.New("the query set is too large")
+			}
+			return []int{1}, nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, recorder.marks["fn/window"])
+	require.Equal(t, 1, recorder.marks["fn/shrink"])
+
+	cache := &dbScanCache[int]{scan: func(
+		context.Context, *store.ScanCursor, int,
+	) ([]int, []store.ScanCursor, error) {
+		return []int{1}, []store.ScanCursor{{BlockNumber: 1}}, nil
+	}}
+	require.NoError(t, cache.Ensure(ctx, 1))
+	require.NoError(t, cache.Ensure(ctx, 1))
+	require.Equal(t, 1, recorder.marks["db/query"])
+	require.Equal(t, 1, recorder.marks["db/cache_reuse"])
+}

--- a/rpc/handler/scan_logs_rpc_test.go
+++ b/rpc/handler/scan_logs_rpc_test.go
@@ -377,13 +377,61 @@ func TestEncodeScanLogsResult(t *testing.T) {
 }
 
 type recordingScanLogsMetrics struct {
-	marks map[string]int
+	marks       map[string]int
+	percentages map[string][]bool
 }
 
-func (m *recordingScanLogsMetrics) Histogram(string, int64)    {}
-func (m *recordingScanLogsMetrics) Percentage(string, bool)    {}
+func (m *recordingScanLogsMetrics) Histogram(string, int64) {}
+func (m *recordingScanLogsMetrics) Percentage(name string, marked bool) {
+	if m.percentages == nil {
+		m.percentages = make(map[string][]bool)
+	}
+	m.percentages[name] = append(m.percentages[name], marked)
+}
 func (m *recordingScanLogsMetrics) Duration(string, time.Time) {}
 func (m *recordingScanLogsMetrics) Mark(name string)           { m.marks[name]++ }
+
+func TestRecordScanLogsCursorOwnerPercentages(t *testing.T) {
+	tests := []struct {
+		name  string
+		owner cursorOwner
+		want  map[string][]bool
+	}{
+		{
+			name: "none", owner: cursorOwnerNone,
+			want: map[string][]bool{
+				"plan/cursor_owner/none": {true},
+				"plan/cursor_owner/db":   {false},
+				"plan/cursor_owner/fn":   {false},
+			},
+		},
+		{
+			name: "db", owner: cursorOwnerDB,
+			want: map[string][]bool{
+				"plan/cursor_owner/none": {false},
+				"plan/cursor_owner/db":   {true},
+				"plan/cursor_owner/fn":   {false},
+			},
+		},
+		{
+			name: "fn", owner: cursorOwnerFN,
+			want: map[string][]bool{
+				"plan/cursor_owner/none": {false},
+				"plan/cursor_owner/db":   {false},
+				"plan/cursor_owner/fn":   {true},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &recordingScanLogsMetrics{}
+			ctx := withScanLogsMetrics(context.Background(), recorder)
+			recordScanLogsCursorOwner(ctx, test.owner)
+			require.Equal(t, test.want, recorder.percentages)
+		})
+	}
+}
 
 func TestScanLogsMetricsRecorderCoversWindowsAndDBCache(t *testing.T) {
 	recorder := &recordingScanLogsMetrics{marks: make(map[string]int)}

--- a/rpc/handler/scan_logs_test.go
+++ b/rpc/handler/scan_logs_test.go
@@ -567,7 +567,7 @@ func TestCfxRouteBReaderFiltersOnlyCursorBlock(t *testing.T) {
 			cfxLog(b5010, epoch, 0),
 		},
 	}
-	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015))
+	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015), nil)
 	require.NoError(t, err)
 	cursor := &store.ScanCursor{BlockNumber: 5009, LogIndex: 2}
 	reader := cfxFNReader{client: client, attempt: attempt, spec: cfxFNReaderSpec{
@@ -592,7 +592,7 @@ func TestCfxRouteBReaderKeepsLaterBlockWhenCursorBlockHasNoLogs(t *testing.T) {
 		byHash: map[cfxtypes.Hash]*cfxtypes.BlockSummary{b5010: cfxSummary(b5010, epoch, 5010)},
 		logs:   []cfxtypes.Log{cfxLog(b5010, epoch, 0)},
 	}
-	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015))
+	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015), nil)
 	require.NoError(t, err)
 	reader := cfxFNReader{client: client, attempt: attempt, spec: cfxFNReaderSpec{
 		blocks: scanRange{From: 5009, To: 5015}, cursor: &store.ScanCursor{BlockNumber: 5009, LogIndex: 2},
@@ -614,7 +614,7 @@ func TestCfxRouteBReaderReverseFiltersCursorBlock(t *testing.T) {
 			cfxLog(b5009, epoch, 4),
 		},
 	}
-	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015))
+	attempt, err := newCfxFNAttemptView(client, epoch+1, cfxSummary(checkpointHash, epoch+1, 5015), nil)
 	require.NoError(t, err)
 	reader := cfxFNReader{client: client, attempt: attempt, spec: cfxFNReaderSpec{
 		blocks: scanRange{From: 5000, To: 5009}, cursor: &store.ScanCursor{BlockNumber: 5009, LogIndex: 3},
@@ -658,7 +658,7 @@ func TestCfxFNReaderRejectsIncompleteLogsBeforeCursorFiltering(t *testing.T) {
 
 			client := &fakeCfxScanClient{logs: []cfxtypes.Log{log}}
 			attempt, err := newCfxFNAttemptView(
-				client, epoch, cfxSummary("0x5010", epoch, 5010),
+				client, epoch, cfxSummary("0x5010", epoch, 5010), nil,
 			)
 			require.NoError(t, err)
 			reader := cfxFNReader{client: client, attempt: attempt, spec: cfxFNReaderSpec{
@@ -681,7 +681,7 @@ func TestCfxRouteBBlockPlanReusesCheckpointAndCursorBoundary(t *testing.T) {
 	client := &fakeCfxScanClient{byNumber: map[uint64]*cfxtypes.BlockSummary{
 		5009: cfxSummary(cursorHash, 105, 5009),
 	}}
-	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100))
+	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100), nil)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(
 		cfxScanGeneration{fnEpochs: scanRange{From: 100, To: checkpointEpoch}},
@@ -702,7 +702,7 @@ func TestCfxRouteBPureFNFirstPageUsesPreviousPivotOnce(t *testing.T) {
 	client := &fakeCfxScanClient{byEpoch: map[uint64]*cfxtypes.BlockSummary{
 		fromEpoch - 1: cfxSummary(previousHash, fromEpoch-1, 4900),
 	}}
-	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100))
+	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100), nil)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(
 		cfxScanGeneration{fnEpochs: scanRange{From: fromEpoch, To: checkpointEpoch}},
@@ -718,7 +718,7 @@ func TestCfxRouteBMixedPageUsesDBBoundaryWithoutRangeRPC(t *testing.T) {
 	const checkpointEpoch = uint64(110)
 	checkpointHash := cfxtypes.Hash("0x5100")
 	client := &fakeCfxScanClient{}
-	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100))
+	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100), nil)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(cfxScanGeneration{
 		dbAvailable: true,
@@ -742,7 +742,7 @@ func TestCfxRouteBReverseCursorResolvesOnlyLowerBoundary(t *testing.T) {
 			5009: cfxSummary(cursorHash, 105, 5009),
 		},
 	}
-	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100))
+	attempt, err := newCfxFNAttemptView(client, checkpointEpoch, cfxSummary(checkpointHash, checkpointEpoch, 5100), nil)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(
 		cfxScanGeneration{fnEpochs: scanRange{From: fromEpoch, To: checkpointEpoch}},
@@ -762,7 +762,7 @@ func TestCfxRouteBResolvesToEpochWhenCheckpointIsHigher(t *testing.T) {
 		toEpoch:       cfxSummary(cfxtypes.Hash("0x5100"), toEpoch, 5100),
 	}}
 	attempt, err := newCfxFNAttemptView(
-		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5200"), checkpointEpoch, 5200),
+		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5200"), checkpointEpoch, 5200), nil,
 	)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(
@@ -779,7 +779,7 @@ func TestCfxRouteBKeepsCursorAboveCheckpointProvisional(t *testing.T) {
 	const checkpointEpoch = uint64(110)
 	client := &fakeCfxScanClient{}
 	attempt, err := newCfxFNAttemptView(
-		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5100"), checkpointEpoch, 5100),
+		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5100"), checkpointEpoch, 5100), nil,
 	)
 	require.NoError(t, err)
 	_, err = attempt.resolveBlockPlan(
@@ -798,7 +798,7 @@ func TestCfxRouteBKeepsCursorOutsideEpochRangeProvisional(t *testing.T) {
 		1000: cfxSummary(cfxtypes.Hash("0x1000"), 105, 1000),
 	}}
 	attempt, err := newCfxFNAttemptView(
-		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x1100"), checkpointEpoch, 1100),
+		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x1100"), checkpointEpoch, 1100), nil,
 	)
 	require.NoError(t, err)
 	_, err = attempt.resolveBlockPlan(
@@ -816,7 +816,7 @@ func TestCfxRouteBTrustsBlockSummaryLookupContract(t *testing.T) {
 		5009: cfxSummary(cfxtypes.Hash("0x5010"), 105, 5010),
 	}}
 	attempt, err := newCfxFNAttemptView(
-		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5100"), checkpointEpoch, 5100),
+		client, checkpointEpoch, cfxSummary(cfxtypes.Hash("0x5100"), checkpointEpoch, 5100), nil,
 	)
 	require.NoError(t, err)
 	plan, err := attempt.resolveBlockPlan(
@@ -834,7 +834,7 @@ func TestBuildCfxInnerCandidateChecksCheckpointAssumptionHash(t *testing.T) {
 	const epoch = uint64(150)
 	realHash := cfxtypes.Hash("0x150b")
 	client := &fakeCfxScanClient{}
-	attempt, err := newCfxFNAttemptView(client, epoch, cfxSummary(realHash, epoch, 6000))
+	attempt, err := newCfxFNAttemptView(client, epoch, cfxSummary(realHash, epoch, 6000), nil)
 	require.NoError(t, err)
 	assumption := &CfxPivotAssumption{EpochNumber: hexutil.Uint64(epoch), PivotBlockHash: cfxtypes.Hash("0x150a")}
 	candidate, err := (&CfxLogsApiHandler{}).buildCfxInnerCandidate(

--- a/rpc/handler/scan_logs_test.go
+++ b/rpc/handler/scan_logs_test.go
@@ -112,7 +112,7 @@ func TestScanLogsErrorsUseFrameworkDefaultCode(t *testing.T) {
 	_, custom := interface{}(ErrScanLogsInvalidCursor).(codedError)
 	assert.False(t, custom)
 	_, custom = newCanonicalDependentError(
-		ErrScanLogsAssumptionNotMet, "assumption validation failed",
+		ErrScanLogsAssumptionFailure, "assumption validation failed",
 	).(codedError)
 	assert.False(t, custom)
 }
@@ -246,7 +246,7 @@ func TestBuildEthInnerCandidateKeepsUnmetAssumptionProvisional(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.ErrorIs(t, candidate.err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, candidate.err, ErrScanLogsAssumptionFailure)
 	assert.True(t, isCanonicalDependentError(candidate.err))
 	assert.True(t, candidate.usage.fn)
 	assert.NotNil(t, candidate.result)
@@ -391,7 +391,7 @@ func TestCfxScanLogsPublicEntryCommitsStableDBError(t *testing.T) {
 		&CfxPivotAssumption{EpochNumber: 10, PivotBlockHash: cfxtypes.Hash("0x02")},
 	)
 
-	require.ErrorIs(t, err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, err, ErrScanLogsAssumptionFailure)
 }
 
 func TestCfxScanLogsPublicEntryRetriesChangedCheckpoint(t *testing.T) {
@@ -849,7 +849,7 @@ func TestBuildCfxInnerCandidateChecksCheckpointAssumptionHash(t *testing.T) {
 		attempt,
 	)
 	require.NoError(t, err)
-	require.ErrorIs(t, candidate.err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, candidate.err, ErrScanLogsAssumptionFailure)
 	assert.True(t, isCanonicalDependentError(candidate.err))
 	assert.True(t, candidate.usage.fn)
 }
@@ -894,7 +894,7 @@ func TestEthScanLogsPublicEntryCommitsStableDBError(t *testing.T) {
 		&EthPivotAssumption{BlockNumber: 10, BlockHash: common.HexToHash("0x02")},
 	)
 
-	require.ErrorIs(t, err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, err, ErrScanLogsAssumptionFailure)
 }
 
 func TestEthScanLogsPublicEntryRetriesChangedCheckpoint(t *testing.T) {
@@ -1035,7 +1035,7 @@ func TestEthScanLogsRejectsNullFNAssumptionBlock(t *testing.T) {
 		&EthPivotAssumption{BlockNumber: 12, BlockHash: assumptionHash},
 	)
 
-	require.ErrorIs(t, err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, err, ErrScanLogsAssumptionFailure)
 	assert.Equal(t, 3, client.blockCalls)
 	assert.Len(t, client.filters, 1)
 }
@@ -1054,7 +1054,7 @@ func TestEthScanLogsRejectsNullCheckpointForFNAssumption(t *testing.T) {
 		&EthPivotAssumption{BlockNumber: 12, BlockHash: common.HexToHash("0x12")},
 	)
 
-	require.ErrorIs(t, err, ErrScanLogsAssumptionNotMet)
+	require.ErrorIs(t, err, ErrScanLogsAssumptionFailure)
 	assert.Equal(t, 1, client.blockCalls)
 	assert.Empty(t, client.filters)
 }

--- a/rpc/server_middleware.go
+++ b/rpc/server_middleware.go
@@ -144,7 +144,7 @@ func getEthClientFromProviderWithContext(
 	grp := node.GroupEthHttp
 
 	switch {
-	case rpcMethod == rpcMethodEthGetLogs:
+	case rpcMethod == rpcMethodEthGetLogs || isEthScanLogsRpcMethod(rpcMethod):
 		grp = node.GroupEthLogs
 	case isEthFilterRpcMethod(rpcMethod):
 		grp = node.GroupEthFilter
@@ -167,7 +167,7 @@ func getCfxClientFromProviderWithContext(
 	grp := node.GroupCfxHttp
 
 	switch {
-	case rpcMethod == rpcMethodCfxGetLogs:
+	case rpcMethod == rpcMethodCfxGetLogs || isCfxScanLogsRpcMethod(rpcMethod):
 		grp = node.GroupCfxLogs
 	case isCfxFilterRpcMethod(rpcMethod):
 		grp = node.GroupCfxFilter

--- a/util/acl/validator.go
+++ b/util/acl/validator.go
@@ -37,8 +37,12 @@ type Validator interface {
 	Validate(ctx Context) error
 }
 
-// parse contract addresses from RPC method params
-type cntAddrParser func(params []interface{}) ([]string, bool)
+// contractAddressParser extracts contract addresses from RPC parameters.
+type contractAddressParser func(params []interface{}) ([]string, bool)
+
+type contractAddressProvider interface {
+	ContractAddress() (string, bool)
+}
 
 // allowlist validator. Each allowlist type is "AND"ed together,
 // while multiple entries of the same type are "OR"ed.
@@ -51,11 +55,11 @@ type validatorBase struct {
 	originRules         []string // request origins
 
 	// contract addresses mapset
-	cntAddrRules map[string]bool
+	contractAddressRules map[string]bool
 
 	// contract address parsers by RPC method params:
-	// RPC method => cntAddrParser
-	cntAddrParsers map[string]cntAddrParser
+	// RPC method => contractAddressParser
+	contractAddressParsers map[string]contractAddressParser
 }
 
 func newValidatorBase(al *AllowList) *validatorBase {
@@ -83,11 +87,11 @@ func newValidatorBase(al *AllowList) *validatorBase {
 	}
 
 	return &validatorBase{
-		AllowList:           al,
-		originRules:         originRules,
-		allowMethodRules:    allowMethodRules,
-		disallowMethodRules: disallowMethodRules,
-		cntAddrRules:        contractAddrRules,
+		AllowList:            al,
+		originRules:          originRules,
+		allowMethodRules:     allowMethodRules,
+		disallowMethodRules:  disallowMethodRules,
+		contractAddressRules: contractAddrRules,
 	}
 }
 
@@ -194,7 +198,7 @@ func (v *validatorBase) validateContractAddresses(ctx Context) error {
 		return nil
 	}
 
-	cntAddrParser, ok := v.cntAddrParsers[ctx.RpcMethod]
+	parseContractAddresses, ok := v.contractAddressParsers[ctx.RpcMethod]
 	if !ok {
 		return nil
 	}
@@ -204,13 +208,13 @@ func (v *validatorBase) validateContractAddresses(ctx Context) error {
 		return errBadRpcParams
 	}
 
-	cntAddrs, ok := cntAddrParser(inputParams)
+	contractAddresses, ok := parseContractAddresses(inputParams)
 	if !ok {
 		return errBadRpcParams
 	}
 
-	for _, caddr := range cntAddrs {
-		if !v.cntAddrRules[strings.ToLower(caddr)] {
+	for _, address := range contractAddresses {
+		if !v.contractAddressRules[strings.ToLower(address)] {
 			return errInvalidContractAddr
 		}
 	}
@@ -227,20 +231,22 @@ func NewEthValidator(al *AllowList) Validator {
 		validatorBase: newValidatorBase(al),
 	}
 
-	v.cntAddrParsers = map[string]cntAddrParser{
-		"eth_call":                v.parseCallRequest,
-		"eth_estimateGas":         v.parseCallRequest,
-		"eth_getLogs":             v.parseFilterQuery,
-		"eth_getBalance":          v.parseAddr,
-		"eth_getTransactionCount": v.parseAddr,
-		"eth_getCode":             v.parseAddr,
-		"eth_getStorageAt":        v.parseAddr,
+	v.contractAddressParsers = map[string]contractAddressParser{
+		"eth_call":                        v.parseCallRequest,
+		"eth_estimateGas":                 v.parseCallRequest,
+		"eth_getLogs":                     v.parseFilterQuery,
+		"eth_scanLogs":                    parseContractAddressProvider,
+		"eth_scanLogsWithPivotAssumption": parseContractAddressProvider,
+		"eth_getBalance":                  v.parseAddr,
+		"eth_getTransactionCount":         v.parseAddr,
+		"eth_getCode":                     v.parseAddr,
+		"eth_getStorageAt":                v.parseAddr,
 	}
 
-	for _, cntAddr := range v.ContractAddresses {
-		if !common.IsHexAddress(cntAddr) {
-			logrus.WithField("contractAddr", cntAddr).Warn("Invalid contract address for allowlist")
-			delete(v.cntAddrRules, strings.ToLower(cntAddr))
+	for _, address := range v.ContractAddresses {
+		if !common.IsHexAddress(address) {
+			logrus.WithField("contractAddr", address).Warn("Invalid contract address for allowlist")
+			delete(v.contractAddressRules, strings.ToLower(address))
 		}
 	}
 
@@ -275,6 +281,21 @@ func (v *EthValidator) parseFilterQuery(params []interface{}) (res []string, ok 
 	return
 }
 
+func parseContractAddressProvider(params []interface{}) ([]string, bool) {
+	if len(params) == 0 {
+		return nil, false
+	}
+
+	req, ok := params[0].(contractAddressProvider)
+	if !ok {
+		return nil, false
+	}
+	if address, exists := req.ContractAddress(); exists {
+		return []string{address}, true
+	}
+	return nil, true
+}
+
 func (v *EthValidator) parseAddr(params []interface{}) (res []string, ok bool) {
 	if len(params) == 0 {
 		return
@@ -297,14 +318,16 @@ func NewCfxValidator(al *AllowList) Validator {
 		validatorBase: newValidatorBase(al),
 	}
 
-	v.cntAddrParsers = map[string]cntAddrParser{
-		"cfx_call":                     v.parseCallRequest,
-		"cfx_estimateGasAndCollateral": v.parseCallRequest,
-		"cfx_getLogs":                  v.parseLogFilter,
-		"cfx_getBalance":               v.parseAddr,
-		"cfx_getNextNonce":             v.parseAddr,
-		"cfx_getCode":                  v.parseAddr,
-		"cfx_getStorageAt":             v.parseAddr,
+	v.contractAddressParsers = map[string]contractAddressParser{
+		"cfx_call":                        v.parseCallRequest,
+		"cfx_estimateGasAndCollateral":    v.parseCallRequest,
+		"cfx_getLogs":                     v.parseLogFilter,
+		"cfx_scanLogs":                    parseContractAddressProvider,
+		"cfx_scanLogsWithPivotAssumption": parseContractAddressProvider,
+		"cfx_getBalance":                  v.parseAddr,
+		"cfx_getNextNonce":                v.parseAddr,
+		"cfx_getCode":                     v.parseAddr,
+		"cfx_getStorageAt":                v.parseAddr,
 	}
 
 	v.uniformContractAddrRulesets()
@@ -312,16 +335,16 @@ func NewCfxValidator(al *AllowList) Validator {
 }
 
 func (v *CfxValidator) uniformContractAddrRulesets() {
-	v.cntAddrRules = make(map[string]bool)
+	v.contractAddressRules = make(map[string]bool)
 
-	for _, cntAddr := range v.ContractAddresses {
-		addr, err := cfxaddress.NewFromBase32(cntAddr)
+	for _, address := range v.ContractAddresses {
+		addr, err := cfxaddress.NewFromBase32(address)
 		if err != nil {
-			logrus.WithField("contractAddr", cntAddr).Warn("Invalid contract address for allowlist")
+			logrus.WithField("contractAddr", address).Warn("Invalid contract address for allowlist")
 			continue
 		}
 
-		v.cntAddrRules[addr.MustGetBase32Address()] = true
+		v.contractAddressRules[addr.MustGetBase32Address()] = true
 	}
 }
 

--- a/util/acl/validator_scan_logs_test.go
+++ b/util/acl/validator_scan_logs_test.go
@@ -1,0 +1,51 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/Conflux-Chain/confura/rpc/handler"
+	"github.com/Conflux-Chain/confura/util/acl"
+	"github.com/Conflux-Chain/go-conflux-sdk/types/cfxaddress"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthScanLogsContractAllowlist(t *testing.T) {
+	allowed := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	denied := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	validator := acl.NewEthValidator(&acl.AllowList{ContractAddresses: []string{allowed.String()}})
+
+	for _, method := range []string{"eth_scanLogs", "eth_scanLogsWithPivotAssumption"} {
+		t.Run(method, func(t *testing.T) {
+			ctx := acl.Context{RpcMethod: method, ExtractRpcParams: func() ([]interface{}, error) {
+				return []interface{}{handler.EthScanLogRequest{Filter: handler.EthScanLogFilter{Address: &allowed}}}, nil
+			}}
+			require.NoError(t, validator.Validate(ctx))
+
+			ctx.ExtractRpcParams = func() ([]interface{}, error) {
+				return []interface{}{handler.EthScanLogRequest{Filter: handler.EthScanLogFilter{Address: &denied}}}, nil
+			}
+			require.ErrorContains(t, validator.Validate(ctx), "invalid contract address")
+		})
+	}
+}
+
+func TestCfxScanLogsContractAllowlist(t *testing.T) {
+	allowed := cfxaddress.MustNewFromHex("0x8111111111111111111111111111111111111111", 1029)
+	denied := cfxaddress.MustNewFromHex("0x8222222222222222222222222222222222222222", 1029)
+	validator := acl.NewCfxValidator(&acl.AllowList{ContractAddresses: []string{allowed.String()}})
+
+	for _, method := range []string{"cfx_scanLogs", "cfx_scanLogsWithPivotAssumption"} {
+		t.Run(method, func(t *testing.T) {
+			ctx := acl.Context{RpcMethod: method, ExtractRpcParams: func() ([]interface{}, error) {
+				return []interface{}{handler.CfxScanLogRequest{Filter: handler.CfxScanLogFilter{Address: &allowed}}}, nil
+			}}
+			require.NoError(t, validator.Validate(ctx))
+
+			ctx.ExtractRpcParams = func() ([]interface{}, error) {
+				return []interface{}{handler.CfxScanLogRequest{Filter: handler.CfxScanLogFilter{Address: &denied}}}, nil
+			}
+			require.ErrorContains(t, validator.Validate(ctx), "invalid contract address")
+		})
+	}
+}

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -101,6 +101,18 @@ func (*RpcMetrics) Percentage(method, name string) metricUtil.Percentage {
 	return metricUtil.GetOrRegisterTimeWindowPercentageDefault("infura/rpc/percentage/%v/%v", method, name)
 }
 
+func (*RpcMetrics) ScanLogsHistogram(method, name string) metrics.Histogram {
+	return metricUtil.GetOrRegisterHistogram("infura/rpc/scanlogs/%v/%v", method, name)
+}
+
+func (*RpcMetrics) ScanLogsMeter(method, name string) metrics.Meter {
+	return metricUtil.GetOrRegisterMeter("infura/rpc/scanlogs/%v/%v", method, name)
+}
+
+func (*RpcMetrics) ScanLogsTimer(method, name string) metrics.Timer {
+	return metricUtil.GetOrRegisterTimer("infura/rpc/scanlogs/%v/%v", method, name)
+}
+
 // RPC metrics - store hit ratio
 
 func (*RpcMetrics) StoreHit(method, storeName string) metricUtil.Percentage {

--- a/util/metrics/metrics.go
+++ b/util/metrics/metrics.go
@@ -101,18 +101,6 @@ func (*RpcMetrics) Percentage(method, name string) metricUtil.Percentage {
 	return metricUtil.GetOrRegisterTimeWindowPercentageDefault("infura/rpc/percentage/%v/%v", method, name)
 }
 
-func (*RpcMetrics) ScanLogsHistogram(method, name string) metrics.Histogram {
-	return metricUtil.GetOrRegisterHistogram("infura/rpc/scanlogs/%v/%v", method, name)
-}
-
-func (*RpcMetrics) ScanLogsMeter(method, name string) metrics.Meter {
-	return metricUtil.GetOrRegisterMeter("infura/rpc/scanlogs/%v/%v", method, name)
-}
-
-func (*RpcMetrics) ScanLogsTimer(method, name string) metrics.Timer {
-	return metricUtil.GetOrRegisterTimer("infura/rpc/scanlogs/%v/%v", method, name)
-}
-
 // RPC metrics - store hit ratio
 
 func (*RpcMetrics) StoreHit(method, storeName string) metricUtil.Percentage {


### PR DESCRIPTION
## Why

Large log-range queries currently depend on `getLogs`, which lacks cursor-based pagination and can produce expensive or oversized requests. Clients need a stable scan API that combines indexed store reads with full-node coverage while detecting canonical-chain changes between pages.

## What Changed

- add Core Space and eSpace `scanLogs` RPC methods, including pivot-assumption variants
- normalize and freeze requested ranges, reject explicit future bounds, and validate cursors and continuation assumptions
- combine store and full-node windows with reorg and canonical-view consistency checks
- encode responses once through `types.Lazy` while enforcing the configured response-size limit
- integrate configuration, ACL address extraction, middleware routing, and scan-specific metrics
- add normalization, cursor, response encoding, pivot guard, ACL, and metrics coverage

## Verification

Targeted tests cover explicit future bounds, dynamic-tag freezing, reversed and pre-hardfork ranges, valid and invalid cursors, and Lazy response-size enforcement.

```sh
go test ./rpc/handler ./rpc ./util/acl
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/415)
<!-- Reviewable:end -->
