### PR TITLE
refactor(mysql): fix partition parameter spelling

### DIFF
--- a/store/mysql/common_partition.go
+++ b/store/mysql/common_partition.go
@@ -98,11 +98,11 @@ func (mrp *mysqlRangePartitioner) addPartition(db *gorm.DB, index int, threshold
 	return db.Exec(sql).Error
 }
 
-func (mrp *mysqlRangePartitioner) removePartition(db *gorm.DB, partiton *mysqlPartition) error {
+func (mrp *mysqlRangePartitioner) removePartition(db *gorm.DB, partition *mysqlPartition) error {
 	sql := fmt.Sprintf(
 		"ALTER TABLE %v DROP PARTITION %v;",
 		mrp.tableName,
-		partiton.Name,
+		partition.Name,
 	)
 	return db.Exec(sql).Error
 }


### PR DESCRIPTION
Renames the private `partiton` parameters to `partition` in the MySQL partition helper. This removes a repeated misspelling and makes the implementation easier to follow without changing exported signatures or runtime behavior.

I have executed `gofmt -d store/mysql/common_partition.go` and `git diff --check` .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/418)
<!-- Reviewable:end -->
