### PR TITLE
refactor(scanlogs): classify errors at semantic boundaries

### DIFF
--- a/rpc/cfx_api.go
+++ b/rpc/cfx_api.go
@@ -302,21 +302,15 @@ func (api *cfxAPI) scanLogs(
 	withPivotAssumption bool,
 ) (cacheTypes.Lazy[*handler.CfxScanLogResult], error) {
 	if api.LogApiHandler == nil {
-		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessage(
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, handler.NewScanLogsErrorf(
 			handler.ErrScanLogsUnavailable, "api handler not configured",
-		)
-	}
-
-	if withPivotAssumption && req.Cursor != nil && assumption == nil {
-		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessagef(
-			handler.ErrScanLogsInvalidParams, "missing pivot assumption",
 		)
 	}
 
 	cfx := GetCfxClientFromContext(ctx)
 	params, err := handler.NormalizeCfxScanLogRequest(cfx, req, withPivotAssumption)
 	if err != nil {
-		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, errors.WithMessage(err, "failed to normalize scan request")
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, err
 	}
 
 	result, err := api.LogApiHandler.ScanLogs(ctx, cfx, params, assumption)

--- a/rpc/cfx_api.go
+++ b/rpc/cfx_api.go
@@ -306,6 +306,9 @@ func (api *cfxAPI) scanLogs(
 			handler.ErrScanLogsUnavailable, "api handler not configured",
 		)
 	}
+	if err := validateScanLogsRequest(withPivotAssumption, req.Cursor, assumption != nil); err != nil {
+		return cacheTypes.Lazy[*handler.CfxScanLogResult]{}, err
+	}
 
 	cfx := GetCfxClientFromContext(ctx)
 	params, err := handler.NormalizeCfxScanLogRequest(cfx, req, withPivotAssumption)

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -528,21 +528,15 @@ func (api *ethAPI) scanLogs(
 	withPivotAssumption bool,
 ) (cacheTypes.Lazy[*handler.EthScanLogResult], error) {
 	if api.LogApiHandler == nil {
-		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessage(
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, handler.NewScanLogsErrorf(
 			handler.ErrScanLogsUnavailable, "api handler not configured",
-		)
-	}
-
-	if withPivotAssumption && req.Cursor != nil && assumption == nil {
-		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessagef(
-			handler.ErrScanLogsInvalidParams, "missing pivot assumption",
 		)
 	}
 
 	w3c := GetEthClientFromContext(ctx)
 	params, err := handler.NormalizeEthScanLogRequest(w3c.Eth, api.hardforkBlockNumber, req, withPivotAssumption)
 	if err != nil {
-		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, errors.WithMessage(err, "failed to normalize scan request")
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, err
 	}
 
 	result, err := api.LogApiHandler.ScanLogs(ctx, w3c.Client.Eth, params, assumption)

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -532,6 +532,9 @@ func (api *ethAPI) scanLogs(
 			handler.ErrScanLogsUnavailable, "api handler not configured",
 		)
 	}
+	if err := validateScanLogsRequest(withPivotAssumption, req.Cursor, assumption != nil); err != nil {
+		return cacheTypes.Lazy[*handler.EthScanLogResult]{}, err
+	}
 
 	w3c := GetEthClientFromContext(ctx)
 	params, err := handler.NormalizeEthScanLogRequest(w3c.Eth, api.hardforkBlockNumber, req, withPivotAssumption)

--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -629,12 +629,6 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 	req CfxScanLogParams,
 	assumption *CfxPivotAssumption,
 ) (result *CfxScanLogResult, err error) {
-	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
-		return nil, NewScanLogsErrorf(
-			ErrScanLogsInvalidParams, "missing pivot assumption",
-		)
-	}
-
 	recorder := newScanLogsMetrics("cfx", req.WithPivotAssumption)
 	ctx = withScanLogsMetrics(ctx, recorder)
 	started := time.Now()

--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -146,11 +146,11 @@ func NormalizeCfxScanLogRequest(
 	resolver cfxEpochNumberResolver,
 	req CfxScanLogRequest,
 	withPivotAssumption bool,
-) (CfxScanLogParams, error) {
+) (params CfxScanLogParams, err error) {
 	// Normalize log limit
 	effectiveLimit, err := normalizeScanLogsLimit(req.Limit)
 	if err != nil {
-		return CfxScanLogParams{}, errors.WithMessage(err, "failed to normalize scan log limit")
+		return params, NewScanLogsError(ErrScanLogsInvalidParams, err)
 	}
 	req.Limit = effectiveLimit
 
@@ -198,7 +198,7 @@ func NormalizeCfxScanLogRequest(
 		return CfxScanLogParams{}, err
 	}
 	if fromNumber > toNumber {
-		return CfxScanLogParams{}, errors.WithMessagef(
+		return CfxScanLogParams{}, NewScanLogsErrorf(
 			ErrScanLogsInvalidParams,
 			"invalid epoch range: from epoch %s exceeds to epoch %s", from, to,
 		)
@@ -214,7 +214,7 @@ func NormalizeCfxScanLogRequest(
 		}
 
 		if toNumber > latestState {
-			return CfxScanLogParams{}, errors.WithMessagef(
+			return CfxScanLogParams{}, NewScanLogsErrorf(
 				ErrScanLogsInvalidParams,
 				"explicit toEpoch %d exceeds frozen latest_state %d", toNumber, latestState,
 			)
@@ -302,7 +302,7 @@ func (handler *CfxLogsApiHandler) buildCfxGeneration(req CfxScanLogParams) (cfxS
 		// failing or guessing a DB split.
 		gen := newCfxFullnodeGeneration(scanRange(req.EpochRange), cursor, req.Reverse)
 		if cursor != nil && gen.fnEpochs.empty() {
-			return cfxScanGeneration{}, errors.WithMessage(
+			return gen, NewScanLogsErrorf(
 				ErrScanLogsInvalidCursor, "cursor is outside of the request range",
 			)
 		}
@@ -325,7 +325,7 @@ func (handler *CfxLogsApiHandler) buildCfxGeneration(req CfxScanLogParams) (cfxS
 		// latest must also exist in a stable Store view. Missing only this endpoint
 		// means the two non-transactional reads crossed a Store change, or the table
 		// is inconsistent; let the outer v0/v1 gate retry or publish the fault.
-		return cfxScanGeneration{}, errors.WithMessage(
+		return cfxScanGeneration{}, NewScanLogsErrorf(
 			ErrScanLogsConsistency, "latest mapping is unavailable while earliest mapping exists",
 		)
 	}
@@ -350,19 +350,19 @@ func (handler *CfxLogsApiHandler) buildCfxGeneration(req CfxScanLogParams) (cfxS
 		// contradicts the continuous DB coverage claimed by the captured watermarks.
 		fromMapping, fromOK, err := handler.ms.BlockMapping(gen.dbEpochs.From)
 		if err != nil {
-			return cfxScanGeneration{}, errors.WithMessage(err, "failed to load block mapping")
+			return gen, errors.WithMessage(err, "failed to load block mapping")
 		}
 
 		toMapping, toOK, err := handler.ms.BlockMapping(gen.dbEpochs.To)
 		if err != nil {
-			return cfxScanGeneration{}, errors.WithMessage(err, "failed to load block mapping")
+			return gen, errors.WithMessage(err, "failed to load block mapping")
 		}
 
 		if !fromOK || !toOK ||
 			fromMapping.BnMin > fromMapping.BnMax ||
 			toMapping.BnMin > toMapping.BnMax ||
 			fromMapping.BnMin > toMapping.BnMax {
-			return cfxScanGeneration{}, errors.WithMessage(
+			return gen, NewScanLogsErrorf(
 				ErrScanLogsConsistency, "inconsistent block mappings",
 			)
 		}
@@ -384,11 +384,12 @@ func (handler *CfxLogsApiHandler) buildCfxGeneration(req CfxScanLogParams) (cfxS
 
 	owner, err := classifyCursorOwner(cursor, gen.dbBlocks, latest.BnMax)
 	if err != nil {
-		return cfxScanGeneration{}, errors.WithMessage(err, "invalid cursor placement")
+		return gen, NewScanLogsError(ErrScanLogsInvalidCursor, err)
 	}
 	if owner == cursorOwnerFN && gen.fnEpochs.empty() {
-		return cfxScanGeneration{}, errors.WithMessage(
-			ErrScanLogsInvalidCursor, "cursor is outside of the segment range",
+		return gen, NewScanLogsErrorf(
+			ErrScanLogsInvalidCursor,
+			"cursor is specified while the split FN segment is empty",
 		)
 	}
 	gen.owner = owner
@@ -498,7 +499,7 @@ func (handler *CfxLogsApiHandler) runCfxPlan(
 			blockPlan, err := attempt.resolveBlockPlan(gen, segment, req.Reverse)
 			if err != nil {
 				result.usage = usage
-				return result, errors.WithMessage(err, "failed to resolve block segment")
+				return result, err
 			}
 
 			reader := &cfxFNReader{
@@ -512,7 +513,7 @@ func (handler *CfxLogsApiHandler) runCfxPlan(
 			batch, err := reader.Scan(ctx, remaining)
 			if err != nil {
 				result.usage = usage
-				return result, errors.WithMessage(err, "failed to scan full node logs")
+				return result, err
 			}
 
 			result.Logs = append(result.Logs, batch.Logs...)
@@ -594,9 +595,7 @@ func (handler *CfxLogsApiHandler) finishCfxCandidate(
 		}
 		pivot, err := attempt.pivot(epoch)
 		if err != nil {
-			return result, errors.WithMessagef(
-				err, "failed to get pivot block for epoch %d", epoch,
-			)
+			return result, err
 		}
 		guard.PivotBlockHash = pivot.hash
 	}
@@ -631,8 +630,8 @@ func (handler *CfxLogsApiHandler) ScanLogs(
 	assumption *CfxPivotAssumption,
 ) (result *CfxScanLogResult, err error) {
 	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
-		return nil, errors.WithMessage(
-			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
+		return nil, NewScanLogsErrorf(
+			ErrScanLogsInvalidParams, "missing pivot assumption",
 		)
 	}
 
@@ -664,10 +663,6 @@ func (handler *CfxLogsApiHandler) scanLogs(
 	req CfxScanLogParams,
 	assumption *CfxPivotAssumption,
 ) (*CfxScanLogResult, error) {
-	if req.Limit == 0 || uint64(req.Limit) > maxScanLogsLimit {
-		return nil, errors.WithMessagef(ErrScanLogsInvalidParams, "scan limit must be in [1, %d]", maxScanLogsLimit)
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, store.TimeoutGetLogs)
 	defer cancel()
 
@@ -697,7 +692,7 @@ func (handler *CfxLogsApiHandler) scanLogs(
 				}
 				return nil, commitErr
 			}
-			return nil, errors.WithMessage(err, "failed to build scan generation")
+			return nil, err
 		}
 
 		recordScanLogsHistogram(ctx, "plan/segments", int64(len(gen.plan.segments)))
@@ -713,7 +708,7 @@ func (handler *CfxLogsApiHandler) scanLogs(
 		// Check DB assumptions if the provided pivot is within the captured DB coverage.
 		dbAssumption, assumptionErr, err := handler.checkCfxDBAssumption(gen, assumption)
 		if err != nil {
-			return nil, errors.WithMessage(err, "failed to check DB assumption")
+			return nil, err
 		}
 		if assumptionErr != nil {
 			_, retryOuter, err := handler.commitCfxDBGeneration(v0, nil, assumptionErr)
@@ -799,13 +794,13 @@ func (handler *CfxLogsApiHandler) checkCfxDBAssumption(
 		return true, nil, errors.WithMessage(err, "failed to load pivot hash")
 	}
 	if !ok {
-		return true, errors.WithMessage(
+		return true, NewScanLogsErrorf(
 			ErrScanLogsConsistency, "pivot mapping is unavailable within captured coverage",
 		), nil
 	}
 
 	if !equalCfxHash(cfxtypes.Hash(pivot), assumption.PivotBlockHash) {
-		return true, errors.WithMessagef(
+		return true, NewScanLogsErrorf(
 			ErrScanLogsAssumptionFailure,
 			"expected pivot %s got %s for epoch %d",
 			assumption.PivotBlockHash, pivot, assumption.EpochNumber,
@@ -905,13 +900,9 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 			boundary, err := attempt.pivot(outer.gen.dbMaxEpoch)
 			if err != nil {
 				if !isCanonicalDependentError(err) {
-					return nil, false, errors.WithMessagef(
-						err, "failed to get boundary summary for epoch %d", outer.gen.dbMaxEpoch,
-					)
+					return nil, false, err
 				}
-				candidate.err = errors.WithMessagef(
-					err, "failed to get boundary summary for epoch %d", outer.gen.dbMaxEpoch,
-				)
+				candidate.err = err
 			} else {
 				boundaryMismatch = !equalCfxHash(boundary.hash, outer.gen.dbPivot)
 			}
@@ -958,7 +949,7 @@ func (handler *CfxLogsApiHandler) scanCfxFullnodeGeneration(
 				markScanLogsMetric(ctx, "boundary/mismatch")
 				if boundaryRetries >= maxBoundaryInnerRetries {
 					markScanLogsMetric(ctx, "boundary/convergence_failure")
-					return nil, false, errors.WithMessagef(
+					return nil, false, NewScanLogsErrorf(
 						ErrScanLogsConsistency, "mixed boundary mismatch after %d retry", boundaryRetries,
 					)
 				}
@@ -1013,7 +1004,7 @@ func (handler *CfxLogsApiHandler) buildCfxInnerCandidate(
 		pivot, err := attempt.pivot(assumptionEpoch)
 		if err != nil {
 			if !isCanonicalDependentError(err) {
-				return cfxInnerCandidate{}, errors.WithMessagef(err, "failed to get block summary for epoch %d", assumptionEpoch)
+				return cfxInnerCandidate{}, err
 			}
 			if provisionalErr == nil {
 				provisionalErr = err
@@ -1235,7 +1226,7 @@ func (v *cfxFNAttemptView) resolveBlockPlan(
 	reverse bool,
 ) (cfxFNBlockPlan, error) {
 	if gen.fnEpochs.empty() {
-		return cfxFNBlockPlan{}, errors.New("empty epoch range")
+		return cfxFNBlockPlan{}, errors.New("cannot resolve block plan for an empty FN epoch range")
 	}
 
 	var cursorRef *cfxBlockRef
@@ -1248,7 +1239,7 @@ func (v *cfxFNAttemptView) resolveBlockPlan(
 		if !gen.fnEpochs.contains(ref.epochNumber) {
 			return cfxFNBlockPlan{}, newCanonicalDependentError(
 				ErrScanLogsInvalidCursor,
-				"cursor block %d belongs to epoch %d outside of segment epochs [%d, %d]",
+				"cursor block %d belongs to epoch %d outside of the FN segment epochs [%d, %d]",
 				segment.cursor.BlockNumber,
 				ref.epochNumber,
 				gen.fnEpochs.From,
@@ -1291,7 +1282,8 @@ func (v *cfxFNAttemptView) resolveBlockPlan(
 
 	if segment.cursor != nil && !blocks.contains(segment.cursor.BlockNumber) {
 		return cfxFNBlockPlan{}, newCanonicalDependentError(
-			ErrScanLogsInvalidCursor, "cursor is outside the resolved block range",
+			ErrScanLogsInvalidCursor,
+			"cursor is outside the resolved FN block range",
 		)
 	}
 

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -137,10 +137,10 @@ func NormalizeEthScanLogRequest(
 	hardfork web3types.BlockNumber,
 	req EthScanLogRequest,
 	withPivotAssumption bool,
-) (EthScanLogParams, error) {
+) (params EthScanLogParams, err error) {
 	effectiveLimit, err := normalizeScanLogsLimit(req.Limit)
 	if err != nil {
-		return EthScanLogParams{}, err
+		return params, NewScanLogsError(ErrScanLogsInvalidParams, err)
 	}
 	req.Limit = effectiveLimit
 
@@ -169,7 +169,7 @@ func NormalizeEthScanLogRequest(
 			return 0, errors.WithMessagef(err, "failed to resolve block by tag %s", blockNum)
 		}
 		if block == nil || block.Number == nil {
-			return 0, errors.WithMessagef(
+			return 0, NewScanLogsErrorf(
 				ErrScanLogsInvalidParams,
 				"unavailable block by tag %s", blockNum,
 			)
@@ -181,14 +181,14 @@ func NormalizeEthScanLogRequest(
 
 	fromNumber, err := resolveBlock(from)
 	if err != nil {
-		return EthScanLogParams{}, err
+		return params, err
 	}
 	toNumber, err := resolveBlock(to)
 	if err != nil {
-		return EthScanLogParams{}, err
+		return params, err
 	}
 	if fromNumber > toNumber {
-		return EthScanLogParams{}, errors.WithMessagef(
+		return params, NewScanLogsErrorf(
 			ErrScanLogsInvalidParams,
 			"invalid block range: from block %s exceeds to block %s", from, to,
 		)
@@ -199,10 +199,10 @@ func NormalizeEthScanLogRequest(
 	if to >= 0 {
 		latest, err := resolveBlock(web3types.LatestBlockNumber)
 		if err != nil {
-			return EthScanLogParams{}, err
+			return params, err
 		}
 		if toNumber > latest {
-			return EthScanLogParams{}, errors.WithMessagef(
+			return params, NewScanLogsErrorf(
 				ErrScanLogsInvalidParams,
 				"explicit toBlock %d exceeds frozen latest %d", toNumber, latest,
 			)
@@ -222,7 +222,7 @@ func NormalizeEthScanLogRequest(
 	}
 
 	if req.Cursor != nil && !effectiveBlockRange.contains(uint64(req.Cursor.BlockNumber)) {
-		return EthScanLogParams{}, errors.WithMessage(
+		return params, NewScanLogsErrorf(
 			ErrScanLogsInvalidCursor, "cursor is outside the normalized block range",
 		)
 	}
@@ -278,7 +278,7 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 	cursor := req.Cursor.toStoreCursor()
 	if scanRange(req.BlockRange).empty() {
 		if cursor != nil {
-			return ethScanGeneration{}, errors.WithMessage(
+			return ethScanGeneration{}, NewScanLogsErrorf(
 				ErrScanLogsInvalidCursor, "cursor is outside of the request range",
 			)
 		}
@@ -295,7 +295,7 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 		// whole range; do not invent a DB split from zero-value mappings.
 		gen := newEthFullnodeGeneration(scanRange(req.BlockRange), cursor, req.Reverse)
 		if cursor != nil && gen.fnBlocks.empty() {
-			return ethScanGeneration{}, errors.WithMessage(
+			return ethScanGeneration{}, NewScanLogsErrorf(
 				ErrScanLogsInvalidCursor, "cursor is outside of the request range",
 			)
 		}
@@ -310,7 +310,7 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 		// Both endpoints come from the same mapping table. Earliest-without-latest
 		// is not an ordinary empty Store; it is a cross-generation read or a broken
 		// Store invariant and must pass through the outer v0/v1 error gate.
-		return ethScanGeneration{}, errors.WithMessage(
+		return ethScanGeneration{}, NewScanLogsErrorf(
 			ErrScanLogsConsistency, "latest mapping is unavailable while earliest mapping exists",
 		)
 	}
@@ -347,11 +347,12 @@ func (handler *EthLogsApiHandler) buildEthGeneration(req EthScanLogParams) (ethS
 
 	owner, err := classifyCursorOwner(cursor, gen.dbBlocks, latest.BnMax)
 	if err != nil {
-		return ethScanGeneration{}, errors.WithMessage(err, "invalid cursor placement")
+		return gen, NewScanLogsError(ErrScanLogsInvalidCursor, err)
 	}
 	if owner == cursorOwnerFN && gen.fnBlocks.empty() {
-		return ethScanGeneration{}, errors.WithMessage(
-			ErrScanLogsInvalidCursor, "cursor is outside of the segment range",
+		return gen, NewScanLogsErrorf(
+			ErrScanLogsInvalidCursor,
+			"cursor is specified while the split FN segment is empty",
 		)
 	}
 	gen.owner = owner
@@ -511,8 +512,8 @@ func (handler *EthLogsApiHandler) ScanLogs(
 	assumption *EthPivotAssumption,
 ) (result *EthScanLogResult, err error) {
 	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
-		return nil, errors.WithMessage(
-			ErrScanLogsInvalidParams, "pivot assumption is required when cursor is provided",
+		return nil, NewScanLogsErrorf(
+			ErrScanLogsInvalidParams, "missing pivot assumption",
 		)
 	}
 
@@ -543,10 +544,6 @@ func (handler *EthLogsApiHandler) scanLogs(
 	req EthScanLogParams,
 	assumption *EthPivotAssumption,
 ) (*EthScanLogResult, error) {
-	if req.Limit == 0 || uint64(req.Limit) > maxScanLogsLimit {
-		return nil, errors.WithMessagef(ErrScanLogsInvalidParams, "scan limit must be in [1, %d]", maxScanLogsLimit)
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, store.TimeoutGetLogs)
 	defer cancel()
 
@@ -698,14 +695,14 @@ func (handler *EthLogsApiHandler) checkEthDBAssumption(
 	if !ok {
 		// The captured watermarks advertised this block as covered. Missing its
 		// identity is therefore a Store fault, not a stale client assumption.
-		return true, errors.WithMessage(
+		return true, NewScanLogsErrorf(
 			ErrScanLogsConsistency,
 			"pivot mapping is unavailable within captured coverage",
 		), nil
 	}
 
 	if common.HexToHash(pivot) != assumption.BlockHash {
-		return true, errors.WithMessagef(
+		return true, NewScanLogsErrorf(
 			ErrScanLogsAssumptionFailure,
 			"expected pivot %s got %s for block %d",
 			assumption.BlockHash, pivot, assumption.BlockNumber,
@@ -767,13 +764,14 @@ func (handler *EthLogsApiHandler) scanEthFullnodeGeneration(
 		}
 		if before == nil {
 			if outer.fnAssumption && uint64(assumption.BlockNumber) == checkpoint {
-				return nil, false, errors.WithMessagef(
+				return nil, false, NewScanLogsErrorf(
 					ErrScanLogsAssumptionFailure,
 					"assumption block %d is unavailable", assumption.BlockNumber,
 				)
 			}
-			return nil, false, errors.WithMessage(
-				ErrScanLogsInvalidFilter, "pre-checkpoint block is unavailable",
+			return nil, false, NewScanLogsErrorf(
+				ErrScanLogsConsistency,
+				"pre-checkpoint block %d is unavailable", checkpoint,
 			)
 		}
 
@@ -829,7 +827,7 @@ func (handler *EthLogsApiHandler) scanEthFullnodeGeneration(
 				markScanLogsMetric(ctx, "boundary/mismatch")
 				if boundaryRetries >= maxBoundaryInnerRetries {
 					markScanLogsMetric(ctx, "boundary/convergence_failure")
-					return nil, false, errors.WithMessagef(
+					return nil, false, NewScanLogsErrorf(
 						ErrScanLogsConsistency, "mixed boundary mismatch after %d retry", boundaryRetries,
 					)
 				}
@@ -870,7 +868,7 @@ func (handler *EthLogsApiHandler) buildEthInnerCandidate(
 		candidate.usage.fn = true
 		cursorBlock := uint64(req.Cursor.BlockNumber)
 		if cursorBlock > checkpoint || !outer.gen.fnBlocks.contains(cursorBlock) {
-			return ethInnerCandidate{}, errors.WithMessage(
+			return ethInnerCandidate{}, NewScanLogsErrorf(
 				ErrScanLogsInvalidCursor, "cursor is outside the request segment",
 			)
 		}
@@ -948,7 +946,7 @@ func (r *ethFNReader) Scan(ctx context.Context, remaining int) (fnSegmentBatch[w
 
 	blocks, err := clipBlockRangeAtCursor(r.spec.blocks, r.spec.cursor, r.spec.reverse)
 	if err != nil {
-		return fnSegmentBatch[web3types.Log]{}, errors.WithMessage(err, "invalid cursor range")
+		return fnSegmentBatch[web3types.Log]{}, NewScanLogsError(ErrScanLogsInvalidCursor, err)
 	}
 
 	var filterFirstWindow func([]web3types.Log) []web3types.Log

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -511,12 +511,6 @@ func (handler *EthLogsApiHandler) ScanLogs(
 	req EthScanLogParams,
 	assumption *EthPivotAssumption,
 ) (result *EthScanLogResult, err error) {
-	if req.WithPivotAssumption && req.Cursor != nil && assumption == nil {
-		return nil, NewScanLogsErrorf(
-			ErrScanLogsInvalidParams, "missing pivot assumption",
-		)
-	}
-
 	recorder := newScanLogsMetrics("eth", req.WithPivotAssumption)
 	ctx = withScanLogsMetrics(ctx, recorder)
 	started := time.Now()

--- a/rpc/handler/scan_logs.go
+++ b/rpc/handler/scan_logs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"slices"
 	"strings"
@@ -84,11 +85,41 @@ var (
 
 	ErrScanLogsInvalidParams = errors.New("invalid scan logs params")
 	ErrScanLogsInvalidCursor = errors.New("invalid scan logs cursor")
-	ErrScanLogsInvalidFilter = errors.New("invalid scan log filter")
 
 	ErrScanLogsConsistency       = errors.New("inconsistent canonical views")
 	ErrScanLogsAssumptionFailure = errors.New("pivot assumption failed")
 )
+
+// scanLogsError keeps the stable client-facing category outside the concrete
+// cause. This makes the message read "category: cause" while preserving both
+// errors.Is category matching and conventional cause traversal.
+type scanLogsError struct {
+	category error
+	cause    error
+}
+
+func (e *scanLogsError) Error() string        { return fmt.Sprintf("%s: %s", e.category, e.cause) }
+func (e *scanLogsError) Unwrap() error        { return e.cause }
+func (e *scanLogsError) Cause() error         { return e.cause }
+func (e *scanLogsError) Is(target error) bool { return errors.Is(e.category, target) }
+
+// NewScanLogsError constructs a categorized scanLogs error. The category is
+// the externally visible manifestation; cause is the concrete failure reason.
+// Neither the returned error nor its category implements a JSON-RPC error code.
+func NewScanLogsError(category, cause error) error {
+	if category == nil {
+		return cause
+	}
+	if cause == nil {
+		return category
+	}
+	return &scanLogsError{category: category, cause: cause}
+}
+
+// NewScanLogsErrorf is the formatted counterpart of NewScanLogsError.
+func NewScanLogsErrorf(category error, format string, args ...any) error {
+	return NewScanLogsError(category, errors.Errorf(format, args...))
+}
 
 // canonicalDependentError marks an error observed from the current canonical
 // chain view. It is provisional until the applicable FN after-check and DB v1
@@ -98,9 +129,10 @@ type canonicalDependentError struct{ err error }
 
 func (e *canonicalDependentError) Error() string { return e.err.Error() }
 func (e *canonicalDependentError) Unwrap() error { return e.err }
+func (e *canonicalDependentError) Cause() error  { return errors.Cause(e.err) }
 
-func newCanonicalDependentError(err error, format string, args ...any) error {
-	return &canonicalDependentError{err: errors.Wrapf(err, format, args...)}
+func newCanonicalDependentError(category error, format string, args ...any) error {
+	return &canonicalDependentError{err: NewScanLogsErrorf(category, format, args...)}
 }
 
 func isCanonicalDependentError(err error) bool {
@@ -170,9 +202,8 @@ func normalizeScanLogsLimit(limit hexutil.Uint64) (hexutil.Uint64, error) {
 		return hexutil.Uint64(defaultScanLogsLimit), nil
 	}
 	if uint64(limit) > maxScanLogsLimit {
-		return 0, errors.WithMessagef(
-			ErrScanLogsInvalidParams,
-			"scan limit %d exceeds configured maximum %d", limit, maxScanLogsLimit,
+		return 0, errors.Errorf(
+			"page limit %d exceeds configured maximum %d", limit, maxScanLogsLimit,
 		)
 	}
 	return limit, nil
@@ -413,8 +444,15 @@ func classifyCursorOwner(
 		return cursorOwnerFN, nil
 	}
 
-	if dbBlocks.empty() || !dbBlocks.contains(cursor.BlockNumber) {
-		return cursorOwnerNone, errors.WithMessage(ErrScanLogsInvalidCursor, "cursor is outside scan range")
+	if dbBlocks.empty() {
+		return cursorOwnerNone, errors.New("cursor is specified while the split DB segment is empty")
+	}
+
+	if !dbBlocks.contains(cursor.BlockNumber) {
+		return cursorOwnerNone, errors.Errorf(
+			"cursor %d is outside the block range [%d, %d] of the split DB segment",
+			cursor.BlockNumber, dbBlocks.From, dbBlocks.To,
+		)
 	}
 	return cursorOwnerDB, nil
 }
@@ -434,7 +472,10 @@ func clipBlockRangeAtCursor(blocks scanRange, cursor *store.ScanCursor, reverse 
 	}
 
 	if blocks.empty() || !blocks.contains(cursor.BlockNumber) {
-		return emptyScanRange, errors.WithMessage(ErrScanLogsInvalidCursor, "cursor is outside block range")
+		return emptyScanRange, errors.Errorf(
+			"cursor %d is outside block range [%d, %d]",
+			cursor.BlockNumber, blocks.From, blocks.To,
+		)
 	}
 
 	if reverse {

--- a/rpc/handler/scan_logs_rpc_test.go
+++ b/rpc/handler/scan_logs_rpc_test.go
@@ -369,7 +369,8 @@ func TestNormalizeScanLogsLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, hexutil.Uint64(25), limit)
 	_, err = normalizeScanLogsLimit(51)
-	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
+	require.NotErrorIs(t, err, ErrScanLogsInvalidParams)
+	require.EqualError(t, err, "page limit 51 exceeds configured maximum 50")
 }
 
 func TestEncodeScanLogsResult(t *testing.T) {

--- a/rpc/handler/scan_logs_test.go
+++ b/rpc/handler/scan_logs_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	web3types "github.com/openweb3/web3go/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -109,18 +110,67 @@ func newTestEthScanLogsHandler(db *gorm.DB) *EthLogsApiHandler {
 func TestScanLogsErrorsUseFrameworkDefaultCode(t *testing.T) {
 	type codedError interface{ ErrorCode() int }
 
-	_, custom := interface{}(ErrScanLogsInvalidCursor).(codedError)
-	assert.False(t, custom)
-	_, custom = newCanonicalDependentError(
+	categories := []error{
+		ErrScanLogsUnavailable,
+		ErrScanLogsInvalidParams,
+		ErrScanLogsInvalidCursor,
+		ErrScanLogsConsistency,
+		ErrScanLogsAssumptionFailure,
+	}
+	for _, category := range categories {
+		t.Run(category.Error(), func(t *testing.T) {
+			cause := errors.New("concrete reason")
+			err := NewScanLogsError(category, cause)
+
+			require.EqualError(t, err, category.Error()+": concrete reason")
+			require.ErrorIs(t, err, category)
+			require.ErrorIs(t, err, cause)
+			assert.Same(t, cause, errors.Cause(err))
+			_, custom := err.(codedError)
+			assert.False(t, custom)
+		})
+	}
+
+	canonical := newCanonicalDependentError(
 		ErrScanLogsAssumptionFailure, "assumption validation failed",
-	).(codedError)
+	)
+	require.EqualError(t, canonical, "pivot assumption failed: assumption validation failed")
+	require.ErrorIs(t, canonical, ErrScanLogsAssumptionFailure)
+	assert.True(t, isCanonicalDependentError(canonical))
+	require.EqualError(t, errors.Cause(canonical), "assumption validation failed")
+	_, custom := canonical.(codedError)
 	assert.False(t, custom)
+}
+
+func TestScanLogsHandlersRequireAssumptionForCursor(t *testing.T) {
+	cfxReq := CfxScanLogParams{
+		CfxScanLogRequest: &CfxScanLogRequest{
+			Limit:  1,
+			Cursor: &ScanLogCursor{},
+		},
+		WithPivotAssumption: true,
+	}
+	_, err := (&CfxLogsApiHandler{}).ScanLogs(context.Background(), nil, cfxReq, nil)
+	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
+	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
+
+	ethReq := EthScanLogParams{
+		EthScanLogRequest: &EthScanLogRequest{
+			Limit:  1,
+			Cursor: &ScanLogCursor{},
+		},
+		WithPivotAssumption: true,
+	}
+	_, err = (&EthLogsApiHandler{}).ScanLogs(context.Background(), nil, ethReq, nil)
+	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
+	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
 }
 
 func TestClassifyCursorOwnerRejectsCursorOutsideRequestDBRange(t *testing.T) {
 	dbRange := scanRange{From: 100, To: 150}
 	owner, err := classifyCursorOwner(&store.ScanCursor{BlockNumber: 90}, dbRange, 200)
-	require.ErrorIs(t, err, ErrScanLogsInvalidCursor)
+	require.EqualError(t, err, "cursor 90 is outside the block range [100, 150] of the split DB segment")
+	require.NotErrorIs(t, err, ErrScanLogsInvalidCursor)
 	assert.Equal(t, cursorOwnerNone, owner)
 
 	owner, err = classifyCursorOwner(&store.ScanCursor{BlockNumber: 120}, dbRange, 200)
@@ -944,7 +994,8 @@ func TestEthScanLogsRejectsNullPreCheckpointBlock(t *testing.T) {
 		nil,
 	)
 
-	require.ErrorIs(t, err, ErrScanLogsInvalidFilter)
+	require.ErrorIs(t, err, ErrScanLogsConsistency)
+	require.EqualError(t, err, "inconsistent canonical views: pre-checkpoint block 10 is unavailable")
 	assert.Equal(t, 1, client.blockCalls)
 	assert.Empty(t, client.filters, "the FN segment must not run without an opening fence")
 }
@@ -1117,6 +1168,22 @@ func TestEthFNReaderDoesNotApplyCursorIndexToLaterBlocks(t *testing.T) {
 	assert.Equal(t, uint(0), batch.Logs[0].Index)
 	require.Len(t, client.filters, 1)
 	assert.Equal(t, web3types.BlockNumber(5009), *client.filters[0].FromBlock)
+}
+
+func TestEthFNReaderClassifiesCursorRangeReason(t *testing.T) {
+	client := &fakeEthScanClient{}
+	reader := ethFNReader{
+		client: client,
+		spec: ethFNReaderSpec{
+			blocks: scanRange{From: 5000, To: 5015},
+			cursor: &store.ScanCursor{BlockNumber: 4999},
+		},
+	}
+
+	_, err := reader.Scan(context.Background(), 10)
+	require.ErrorIs(t, err, ErrScanLogsInvalidCursor)
+	require.EqualError(t, err, "invalid scan logs cursor: cursor 4999 is outside block range [5000, 5015]")
+	assert.Empty(t, client.filters)
 }
 
 func TestEthFNReaderUsesHigherFenceInsteadOfCursorHashLookup(t *testing.T) {

--- a/rpc/handler/scan_logs_test.go
+++ b/rpc/handler/scan_logs_test.go
@@ -142,30 +142,6 @@ func TestScanLogsErrorsUseFrameworkDefaultCode(t *testing.T) {
 	assert.False(t, custom)
 }
 
-func TestScanLogsHandlersRequireAssumptionForCursor(t *testing.T) {
-	cfxReq := CfxScanLogParams{
-		CfxScanLogRequest: &CfxScanLogRequest{
-			Limit:  1,
-			Cursor: &ScanLogCursor{},
-		},
-		WithPivotAssumption: true,
-	}
-	_, err := (&CfxLogsApiHandler{}).ScanLogs(context.Background(), nil, cfxReq, nil)
-	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
-	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
-
-	ethReq := EthScanLogParams{
-		EthScanLogRequest: &EthScanLogRequest{
-			Limit:  1,
-			Cursor: &ScanLogCursor{},
-		},
-		WithPivotAssumption: true,
-	}
-	_, err = (&EthLogsApiHandler{}).ScanLogs(context.Background(), nil, ethReq, nil)
-	require.ErrorIs(t, err, ErrScanLogsInvalidParams)
-	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
-}
-
 func TestClassifyCursorOwnerRejectsCursorOutsideRequestDBRange(t *testing.T) {
 	dbRange := scanRange{From: 100, To: 150}
 	owner, err := classifyCursorOwner(&store.ScanCursor{BlockNumber: 90}, dbRange, 200)

--- a/rpc/scan_logs.go
+++ b/rpc/scan_logs.go
@@ -1,0 +1,18 @@
+package rpc
+
+import "github.com/Conflux-Chain/confura/rpc/handler"
+
+// validateScanLogsRequest rejects request-shape errors that can be determined
+// before normalization performs any full-node lookups.
+func validateScanLogsRequest(
+	withPivotAssumption bool,
+	cursor *handler.ScanLogCursor,
+	assumptionProvided bool,
+) error {
+	if withPivotAssumption && cursor != nil && !assumptionProvided {
+		return handler.NewScanLogsErrorf(
+			handler.ErrScanLogsInvalidParams, "missing pivot assumption",
+		)
+	}
+	return nil
+}

--- a/rpc/scan_logs_error_test.go
+++ b/rpc/scan_logs_error_test.go
@@ -14,6 +14,11 @@ func TestCfxScanLogsEntryErrorCategories(t *testing.T) {
 	require.ErrorIs(t, err, handler.ErrScanLogsUnavailable)
 	require.EqualError(t, err, "scan logs rpc unavailable: api handler not configured")
 
+	api.LogApiHandler = &handler.CfxLogsApiHandler{}
+	request := handler.CfxScanLogRequest{Cursor: &handler.ScanLogCursor{}}
+	_, err = api.scanLogs(context.Background(), request, nil, true)
+	require.ErrorIs(t, err, handler.ErrScanLogsInvalidParams)
+	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
 }
 
 func TestEthScanLogsEntryErrorCategories(t *testing.T) {
@@ -22,4 +27,31 @@ func TestEthScanLogsEntryErrorCategories(t *testing.T) {
 	require.ErrorIs(t, err, handler.ErrScanLogsUnavailable)
 	require.EqualError(t, err, "scan logs rpc unavailable: api handler not configured")
 
+	api.LogApiHandler = &handler.EthLogsApiHandler{}
+	request := handler.EthScanLogRequest{Cursor: &handler.ScanLogCursor{}}
+	_, err = api.scanLogs(context.Background(), request, nil, true)
+	require.ErrorIs(t, err, handler.ErrScanLogsInvalidParams)
+	require.EqualError(t, err, "invalid scan logs params: missing pivot assumption")
+}
+
+func TestValidateScanLogsRequestAllowsOtherShapes(t *testing.T) {
+	cursor := &handler.ScanLogCursor{}
+	tests := []struct {
+		name                string
+		withPivotAssumption bool
+		cursor              *handler.ScanLogCursor
+		assumptionProvided  bool
+	}{
+		{name: "with assumption", withPivotAssumption: true, cursor: cursor, assumptionProvided: true},
+		{name: "first page", withPivotAssumption: true},
+		{name: "plain scan logs", cursor: cursor},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, validateScanLogsRequest(
+				test.withPivotAssumption, test.cursor, test.assumptionProvided,
+			))
+		})
+	}
 }

--- a/rpc/scan_logs_error_test.go
+++ b/rpc/scan_logs_error_test.go
@@ -1,0 +1,25 @@
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Conflux-Chain/confura/rpc/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCfxScanLogsEntryErrorCategories(t *testing.T) {
+	api := &cfxAPI{}
+	_, err := api.scanLogs(context.Background(), handler.CfxScanLogRequest{}, nil, false)
+	require.ErrorIs(t, err, handler.ErrScanLogsUnavailable)
+	require.EqualError(t, err, "scan logs rpc unavailable: api handler not configured")
+
+}
+
+func TestEthScanLogsEntryErrorCategories(t *testing.T) {
+	api := &ethAPI{}
+	_, err := api.scanLogs(context.Background(), handler.EthScanLogRequest{}, nil, false)
+	require.ErrorIs(t, err, handler.ErrScanLogsUnavailable)
+	require.EqualError(t, err, "scan logs rpc unavailable: api handler not configured")
+
+}


### PR DESCRIPTION
## Why

`scanLogs` errors were categorized and wrapped at multiple call layers, which made ownership unclear, produced inconsistent error messages, and left `InvalidFilter` attached to failures that were actually cursor or canonical-view problems. Repeated validation in the API and private handler path also duplicated assumptions about already-normalized requests.

## What Changed

- Add a category/cause error wrapper that preserves stable `errors.Is` matching while exposing messages as `category: cause`.
- Keep shared helpers category-free, classify failures once at the first layer that understands their business meaning, and directly propagate categorized errors through callers.
- Validate missing pivot assumptions in a shared RPC preflight before client lookup and normalization; rely on RPC normalization as the single owner of limit validation.
- Remove `ErrScanLogsInvalidFilter`; classify cursor-range failures as `InvalidCursor` and unavailable checkpoint blocks as `Consistency`.
- Extend Core Space and eSpace tests for category matching, cause traversal, handler validation, cursor ownership, and checkpoint consistency.

<!-- Reviewable:start -->
---
[<img src="https://reviewable.io/review_button.svg" alt="Reviewable" height="35">](https://reviewable.io/reviews/Conflux-Chain/confura/419)
<!-- Reviewable:end -->
