### PR TITLE
refactor(rpc): flatten scanLogs filter ranges

### DIFF
--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -14,31 +14,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-type CfxEpochRange struct {
-	From *cfxtypes.Epoch `json:"fromEpoch,omitempty"`
-	To   *cfxtypes.Epoch `json:"toEpoch,omitempty"`
-}
-
-func (r *CfxEpochRange) UnmarshalJSON(data []byte) error {
-	type plain CfxEpochRange
-	var decoded plain
-
-	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
-		return errors.WithMessage(err, "invalid epoch range")
-	}
-
-	if err := validateJSONObjectFields(data, nil, []string{"fromEpoch", "toEpoch"}); err != nil {
-		return err
-	}
-
-	*r = CfxEpochRange(decoded)
-	return nil
-}
-
 type CfxScanLogFilter struct {
-	EpochRange *CfxEpochRange      `json:"epochRange,omitempty"`
-	Address    *cfxaddress.Address `json:"address,omitempty"`
-	Topic0     *cfxtypes.Hash      `json:"topic0,omitempty"`
+	FromEpoch *cfxtypes.Epoch     `json:"fromEpoch,omitempty"`
+	ToEpoch   *cfxtypes.Epoch     `json:"toEpoch,omitempty"`
+	Address   *cfxaddress.Address `json:"address,omitempty"`
+	Topic0    *cfxtypes.Hash      `json:"topic0,omitempty"`
 }
 
 func (f *CfxScanLogFilter) UnmarshalJSON(data []byte) error {
@@ -48,14 +28,14 @@ func (f *CfxScanLogFilter) UnmarshalJSON(data []byte) error {
 	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
 		return errors.WithMessage(err, "invalid scan filter")
 	}
-	if err := validateJSONObjectFields(data, nil, []string{"epochRange", "address", "topic0"}); err != nil {
+	if err := validateJSONObjectFields(data, nil, []string{"fromEpoch", "toEpoch", "address", "topic0"}); err != nil {
 		return err
 	}
 	*f = CfxScanLogFilter(decoded)
 	return nil
 }
 
-// CfxScanLogRequest is the JSON-RPC request shape. EpochRange may still contain
+// CfxScanLogRequest is the JSON-RPC request shape. Epoch bounds may still contain
 // tags and must be normalized before entering the Handler.
 type CfxScanLogRequest struct {
 	Filter  CfxScanLogFilter `json:"filter"`
@@ -156,13 +136,11 @@ func NormalizeCfxScanLogRequest(
 
 	// Normalize epoch range
 	from, to := cfxtypes.EpochLatestState, cfxtypes.EpochLatestState
-	if req.Filter.EpochRange != nil {
-		if req.Filter.EpochRange.From != nil {
-			from = req.Filter.EpochRange.From
-		}
-		if req.Filter.EpochRange.To != nil {
-			to = req.Filter.EpochRange.To
-		}
+	if req.Filter.FromEpoch != nil {
+		from = req.Filter.FromEpoch
+	}
+	if req.Filter.ToEpoch != nil {
+		to = req.Filter.ToEpoch
 	}
 
 	resolvedTags := make(map[string]uint64)

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -12,28 +12,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-type EthBlockRange struct {
-	From *web3types.BlockNumber `json:"fromBlock,omitempty"`
-	To   *web3types.BlockNumber `json:"toBlock,omitempty"`
-}
-
-func (r *EthBlockRange) UnmarshalJSON(data []byte) error {
-	type plain EthBlockRange
-	var decoded plain
-	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
-		return errors.WithMessage(err, "invalid eSpace block range")
-	}
-	if err := validateJSONObjectFields(data, nil, []string{"fromBlock", "toBlock"}); err != nil {
-		return err
-	}
-	*r = EthBlockRange(decoded)
-	return nil
-}
-
 type EthScanLogFilter struct {
-	BlockRange *EthBlockRange  `json:"blockRange,omitempty"`
-	Address    *common.Address `json:"address,omitempty"`
-	Topic0     *common.Hash    `json:"topic0,omitempty"`
+	FromBlock *web3types.BlockNumber `json:"fromBlock,omitempty"`
+	ToBlock   *web3types.BlockNumber `json:"toBlock,omitempty"`
+	Address   *common.Address        `json:"address,omitempty"`
+	Topic0    *common.Hash           `json:"topic0,omitempty"`
 }
 
 func (f *EthScanLogFilter) UnmarshalJSON(data []byte) error {
@@ -42,7 +25,7 @@ func (f *EthScanLogFilter) UnmarshalJSON(data []byte) error {
 	if err := unmarshalStrictJSONObject(data, &decoded); err != nil {
 		return errors.WithMessage(err, "invalid eSpace scan filter")
 	}
-	if err := validateJSONObjectFields(data, nil, []string{"blockRange", "address", "topic0"}); err != nil {
+	if err := validateJSONObjectFields(data, nil, []string{"fromBlock", "toBlock", "address", "topic0"}); err != nil {
 		return err
 	}
 	*f = EthScanLogFilter(decoded)
@@ -145,13 +128,11 @@ func NormalizeEthScanLogRequest(
 	req.Limit = effectiveLimit
 
 	from, to := web3types.LatestBlockNumber, web3types.LatestBlockNumber
-	if req.Filter.BlockRange != nil {
-		if req.Filter.BlockRange.From != nil {
-			from = *req.Filter.BlockRange.From
-		}
-		if req.Filter.BlockRange.To != nil {
-			to = *req.Filter.BlockRange.To
-		}
+	if req.Filter.FromBlock != nil {
+		from = *req.Filter.FromBlock
+	}
+	if req.Filter.ToBlock != nil {
+		to = *req.Filter.ToBlock
 	}
 
 	resolvedTags := make(map[web3types.BlockNumber]uint64)

--- a/rpc/handler/scan_logs_rpc_test.go
+++ b/rpc/handler/scan_logs_rpc_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/Conflux-Chain/confura/store"
 	citypes "github.com/Conflux-Chain/confura/types"
 	cfxtypes "github.com/Conflux-Chain/go-conflux-sdk/types"
+	"github.com/Conflux-Chain/go-conflux-sdk/types/cfxaddress"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	web3types "github.com/openweb3/web3go/types"
@@ -117,7 +119,7 @@ func TestNormalizeCfxScanLogRequest(t *testing.T) {
 			params, err := NormalizeCfxScanLogRequest(
 				resolver,
 				CfxScanLogRequest{
-					Filter: CfxScanLogFilter{EpochRange: &CfxEpochRange{From: test.from, To: test.to}},
+					Filter: CfxScanLogFilter{FromEpoch: test.from, ToEpoch: test.to},
 					Limit:  1,
 				},
 				false,
@@ -234,7 +236,7 @@ func TestNormalizeEthScanLogRequest(t *testing.T) {
 				resolver,
 				test.hardfork,
 				EthScanLogRequest{
-					Filter: EthScanLogFilter{BlockRange: &EthBlockRange{From: test.from, To: test.to}},
+					Filter: EthScanLogFilter{FromBlock: test.from, ToBlock: test.to},
 					Limit:  1,
 					Cursor: test.cursor,
 				},
@@ -302,7 +304,7 @@ func TestScanLogsOptionalFilter(t *testing.T) {
 func TestScanLogsJSONQuantitiesAndFirstPageGuard(t *testing.T) {
 	var req EthScanLogRequest
 	require.NoError(t, json.Unmarshal([]byte(`{
-		"filter":{"blockRange":{"fromBlock":"0x1","toBlock":"latest"}},
+		"filter":{"fromBlock":"0x1","toBlock":"latest"},
 		"limit":"0x64",
 		"cursor":{"blockNumber":"0xa","logIndex":"0x2"}
 	}`), &req))
@@ -481,4 +483,75 @@ func TestScanLogsMetricsRecorderCoversWindowsAndDBCache(t *testing.T) {
 	require.NoError(t, cache.Ensure(ctx, 1))
 	require.Equal(t, 1, recorder.marks["db/query"])
 	require.Equal(t, 1, recorder.marks["db/cache_reuse"])
+}
+
+func TestScanLogsFlatFilterJSON(t *testing.T) {
+	for _, chain := range []string{"cfx", "eth"} {
+		t.Run(chain, func(t *testing.T) {
+			suffix, wrapper := "Block", "blockRange"
+			address := common.HexToAddress("0x8111111111111111111111111111111111111111").String()
+			newRequest := func() interface{} { return new(EthScanLogRequest) }
+			if chain == "cfx" {
+				suffix, wrapper = "Epoch", "epochRange"
+				cfxAddress := cfxaddress.MustNewFromHex(address, 1029)
+				address = cfxAddress.MustGetBase32Address()
+				newRequest = func() interface{} { return new(CfxScanLogRequest) }
+			}
+			payload := fmt.Sprintf(`{"from%s":"0x1","to%s":"0x64","address":"%s","topic0":"%s"}`, suffix, suffix, address, common.HexToHash("0x1").String())
+			req := newRequest()
+			require.NoError(t, json.Unmarshal([]byte(`{"filter":`+payload+`}`), req))
+			var filter interface{}
+			switch req := req.(type) {
+			case *CfxScanLogRequest:
+				require.Equal(t, epochNumber(1), req.Filter.FromEpoch)
+				require.Equal(t, epochNumber(100), req.Filter.ToEpoch)
+				filter = req.Filter
+			case *EthScanLogRequest:
+				require.Equal(t, blockNumber(1), req.Filter.FromBlock)
+				require.Equal(t, blockNumber(100), req.Filter.ToBlock)
+				filter = req.Filter
+			}
+			encoded, err := json.Marshal(filter)
+			require.NoError(t, err)
+			require.JSONEq(t, payload, string(encoded))
+
+			for _, invalid := range []string{
+				fmt.Sprintf(`{"%s":{"from%s":"0x1"}}`, wrapper, suffix),
+				fmt.Sprintf(`{"from%s":null}`, suffix),
+				fmt.Sprintf(`{"to%s":null}`, suffix),
+				fmt.Sprintf(`{"from%s":"invalid"}`, suffix),
+				fmt.Sprintf(`{"to%s":"invalid"}`, suffix),
+				`{"from":"0x1"}`,
+			} {
+				require.Error(t, json.Unmarshal([]byte(`{"filter":`+invalid+`}`), newRequest()), invalid)
+			}
+
+			for _, test := range []struct {
+				payload  string
+				from, to uint64
+			}{
+				{`{}`, 100, 100},
+				{`{"filter":{}}`, 100, 100},
+				{fmt.Sprintf(`{"filter":{"from%s":"0x1"}}`, suffix), 1, 100},
+				{fmt.Sprintf(`{"filter":{"to%s":"0x64"}}`, suffix), 100, 100},
+			} {
+				t.Run(test.payload, func(t *testing.T) {
+					req := newRequest()
+					require.NoError(t, json.Unmarshal([]byte(test.payload), req))
+					var got citypes.RangeUint64
+					switch req := req.(type) {
+					case *CfxScanLogRequest:
+						params, err := NormalizeCfxScanLogRequest(&fakeCfxEpochNumberResolver{values: map[string]uint64{cfxtypes.EpochLatestState.String(): 100}}, *req, false)
+						require.NoError(t, err)
+						got = params.EpochRange
+					case *EthScanLogRequest:
+						params, err := NormalizeEthScanLogRequest(&fakeEthBlockNumberResolver{values: map[web3types.BlockNumber]uint64{web3types.LatestBlockNumber: 100}}, 0, *req, false)
+						require.NoError(t, err)
+						got = params.BlockRange
+					}
+					require.Equal(t, citypes.RangeUint64{From: test.from, To: test.to}, got)
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Why

The `epochRange` and `blockRange` wrappers make scanLogs filters unnecessarily verbose. Flattening the bounds makes requests easier to write and aligns their field layout with native log filters.

## What Changed

Move `fromEpoch` / `toEpoch` and `fromBlock` / `toBlock` directly into `filter` for both scanLogs methods and their pivot-assumption variants. Remove the request-only range types and read the flat fields during normalization; internal normalized ranges and scanning behavior remain unchanged.

This is a breaking request-format change: callers must remove the old wrappers, which strict JSON decoding now rejects. Omitted bounds retain their existing defaults, and explicit null bounds remain invalid.

## Verification

`TestScanLogsFlatFilterJSON` verifies flat bounds round-trip alongside `address` and `topic0`, rejects legacy wrappers and invalid bounds, and checks the normalized defaults for omitted filters and one-sided ranges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/420)
<!-- Reviewable:end -->
