### PR TITLE
refactor(rpc): accept decimal `scanLogs` limits

### DIFF
--- a/rpc/handler/cfx_scan_logs.go
+++ b/rpc/handler/cfx_scan_logs.go
@@ -39,7 +39,7 @@ func (f *CfxScanLogFilter) UnmarshalJSON(data []byte) error {
 // tags and must be normalized before entering the Handler.
 type CfxScanLogRequest struct {
 	Filter  CfxScanLogFilter `json:"filter"`
-	Limit   hexutil.Uint64   `json:"limit"`
+	Limit   uint64           `json:"limit"`
 	Cursor  *ScanLogCursor   `json:"cursor,omitempty"`
 	Reverse bool             `json:"reverse,omitempty"`
 }

--- a/rpc/handler/eth_scan_logs.go
+++ b/rpc/handler/eth_scan_logs.go
@@ -34,7 +34,7 @@ func (f *EthScanLogFilter) UnmarshalJSON(data []byte) error {
 
 type EthScanLogRequest struct {
 	Filter  EthScanLogFilter `json:"filter"`
-	Limit   hexutil.Uint64   `json:"limit"`
+	Limit   uint64           `json:"limit"`
 	Cursor  *ScanLogCursor   `json:"cursor,omitempty"`
 	Reverse bool             `json:"reverse,omitempty"`
 }

--- a/rpc/handler/scan_logs.go
+++ b/rpc/handler/scan_logs.go
@@ -197,11 +197,11 @@ func unmarshalStrictJSONObject(data []byte, dst any) error {
 	return nil
 }
 
-func normalizeScanLogsLimit(limit hexutil.Uint64) (hexutil.Uint64, error) {
+func normalizeScanLogsLimit(limit uint64) (uint64, error) {
 	if limit == 0 {
-		return hexutil.Uint64(defaultScanLogsLimit), nil
+		return defaultScanLogsLimit, nil
 	}
-	if uint64(limit) > maxScanLogsLimit {
+	if limit > maxScanLogsLimit {
 		return 0, errors.Errorf(
 			"page limit %d exceeds configured maximum %d", limit, maxScanLogsLimit,
 		)

--- a/rpc/handler/scan_logs_rpc_test.go
+++ b/rpc/handler/scan_logs_rpc_test.go
@@ -305,10 +305,10 @@ func TestScanLogsJSONQuantitiesAndFirstPageGuard(t *testing.T) {
 	var req EthScanLogRequest
 	require.NoError(t, json.Unmarshal([]byte(`{
 		"filter":{"fromBlock":"0x1","toBlock":"latest"},
-		"limit":"0x64",
+		"limit":100,
 		"cursor":{"blockNumber":"0xa","logIndex":"0x2"}
 	}`), &req))
-	require.Equal(t, hexutil.Uint64(100), req.Limit)
+	require.Equal(t, uint64(100), req.Limit)
 	require.Equal(t, hexutil.Uint64(10), req.Cursor.BlockNumber)
 
 	log := web3types.Log{BlockNumber: 10, BlockHash: common.HexToHash("0x1234")}
@@ -360,6 +360,63 @@ func TestScanLogsJSONQuantitiesAndFirstPageGuard(t *testing.T) {
 	require.Equal(t, cfxtypes.Hash(pivot.String()), cfxResult.PivotGuard.PivotBlockHash)
 }
 
+func TestScanLogsLimitJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		data  string
+		valid bool
+	}{
+		{"integer", `{"filter":{},"limit":100}`, true},
+		{"omitted", `{"filter":{}}`, true},
+		{"zero", `{"filter":{},"limit":0}`, true},
+		{"hex string", `{"filter":{},"limit":"0x64"}`, false},
+		{"decimal string", `{"filter":{},"limit":"100"}`, false},
+		{"negative", `{"filter":{},"limit":-1}`, false},
+		{"fraction", `{"filter":{},"limit":1.5}`, false},
+		{"too large for uint64", `{"filter":{},"limit":18446744073709551616}`, false},
+	}
+
+	for _, chain := range []struct {
+		name    string
+		newReq  func() interface{}
+		limitOf func(interface{}) uint64
+	}{
+		{
+			name:   "cfx",
+			newReq: func() interface{} { return new(CfxScanLogRequest) },
+			limitOf: func(req interface{}) uint64 {
+				return req.(*CfxScanLogRequest).Limit
+			},
+		},
+		{
+			name:   "eth",
+			newReq: func() interface{} { return new(EthScanLogRequest) },
+			limitOf: func(req interface{}) uint64 {
+				return req.(*EthScanLogRequest).Limit
+			},
+		},
+	} {
+		t.Run(chain.name, func(t *testing.T) {
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					req := chain.newReq()
+					err := json.Unmarshal([]byte(test.data), req)
+					if !test.valid {
+						require.Error(t, err)
+						return
+					}
+					require.NoError(t, err)
+					if test.name == "integer" {
+						require.Equal(t, uint64(100), chain.limitOf(req))
+					} else {
+						require.Zero(t, chain.limitOf(req))
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestNormalizeScanLogsLimit(t *testing.T) {
 	oldDefault, oldMax := defaultScanLogsLimit, maxScanLogsLimit
 	t.Cleanup(func() {
@@ -369,7 +426,7 @@ func TestNormalizeScanLogsLimit(t *testing.T) {
 
 	limit, err := normalizeScanLogsLimit(0)
 	require.NoError(t, err)
-	require.Equal(t, hexutil.Uint64(25), limit)
+	require.Equal(t, uint64(25), limit)
 	_, err = normalizeScanLogsLimit(51)
 	require.NotErrorIs(t, err, ErrScanLogsInvalidParams)
 	require.EqualError(t, err, "page limit 51 exceeds configured maximum 50")


### PR DESCRIPTION
## Why

`scanLogs` currently decodes `limit` as `hexutil.Uint64`, forcing JSON-RPC callers to send a hexadecimal string for a small bounded page size.

## What Changed

Decode `limit` as a `uint64` JSON number for both CFX and ETH scanLogs requests. Existing default and maximum limit validation remains unchanged, while string, fractional, negative, and out-of-range values are rejected.

Add request decoding coverage for valid numeric limits and invalid representations across both APIs.

## Verification

`go test ./rpc/handler ./rpc ./util/acl`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/confura/421)
<!-- Reviewable:end -->
